### PR TITLE
Add plot rendering for workouts

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,6 +10,7 @@ dependencies = [
  "csv",
  "eframe",
  "egui",
+ "egui_plot",
  "rfd",
  "serde",
 ]
@@ -1149,6 +1150,15 @@ dependencies = [
  "wasm-bindgen",
  "web-sys",
  "winit",
+]
+
+[[package]]
+name = "egui_plot"
+version = "0.27.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a7854b86dc1c2d352c5270db3d600011daa913d6b554141a03939761323288a1"
+dependencies = [
+ "egui",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,3 +10,4 @@ csv = "1"
 serde = { version = "1", features = ["derive"] }
 chrono = "0.4"
 rfd = "0.14"
+egui_plot = "0.27"

--- a/src/analysis.rs
+++ b/src/analysis.rs
@@ -1,6 +1,6 @@
 // Module for analyzing workout data
 use crate::WorkoutEntry;
-use chrono::{NaiveDate};
+use chrono::NaiveDate;
 use std::collections::HashMap;
 
 #[derive(Debug, Default, PartialEq)]
@@ -75,10 +75,30 @@ mod tests {
 
     fn sample_entries() -> Vec<WorkoutEntry> {
         vec![
-            WorkoutEntry { date: "2024-01-01".into(), exercise: "Squat".into(), weight: 100.0, reps: 5 },
-            WorkoutEntry { date: "2024-01-01".into(), exercise: "Bench".into(), weight: 80.0, reps: 5 },
-            WorkoutEntry { date: "2024-01-03".into(), exercise: "Squat".into(), weight: 105.0, reps: 5 },
-            WorkoutEntry { date: "2024-01-05".into(), exercise: "Deadlift".into(), weight: 120.0, reps: 5 },
+            WorkoutEntry {
+                date: "2024-01-01".into(),
+                exercise: "Squat".into(),
+                weight: 100.0,
+                reps: 5,
+            },
+            WorkoutEntry {
+                date: "2024-01-01".into(),
+                exercise: "Bench".into(),
+                weight: 80.0,
+                reps: 5,
+            },
+            WorkoutEntry {
+                date: "2024-01-03".into(),
+                exercise: "Squat".into(),
+                weight: 105.0,
+                reps: 5,
+            },
+            WorkoutEntry {
+                date: "2024-01-05".into(),
+                exercise: "Deadlift".into(),
+                weight: 120.0,
+                reps: 5,
+            },
         ]
     }
 
@@ -88,7 +108,7 @@ mod tests {
         let stats = compute_stats(&entries);
         assert_eq!(stats.total_workouts, 3);
         // total sets = 4, workouts = 3 -> avg 1.333...
-        assert!((stats.avg_sets_per_workout - 4f32/3f32).abs() < 1e-6);
+        assert!((stats.avg_sets_per_workout - 4f32 / 3f32).abs() < 1e-6);
         assert!((stats.avg_reps_per_set - 5.0).abs() < 1e-6);
         assert!((stats.avg_days_between - 2.0).abs() < 1e-6); // (2 + 2)/2
         assert_eq!(stats.most_common_exercise.as_deref(), Some("Squat"));

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,12 +1,15 @@
-use eframe::{egui, App, Frame, NativeOptions};
-use serde::Deserialize;
+use eframe::{App, Frame, NativeOptions, egui};
+use egui_plot::Plot;
 use rfd::FileDialog;
+use serde::Deserialize;
 use std::fs::File;
 
 mod analysis;
-use analysis::{compute_stats, BasicStats};
+use analysis::{BasicStats, compute_stats};
+mod plotting;
+use plotting::{estimated_1rm_line, sets_per_day_bar, unique_exercises, weight_over_time_line};
 
-#[derive(Debug, Deserialize)]
+#[derive(Debug, Deserialize, Clone)]
 struct WorkoutEntry {
     date: String,
     exercise: String,
@@ -17,6 +20,7 @@ struct WorkoutEntry {
 struct MyApp {
     workouts: Vec<WorkoutEntry>,
     stats: BasicStats,
+    selected_exercise: Option<String>,
 }
 
 impl Default for MyApp {
@@ -24,6 +28,7 @@ impl Default for MyApp {
         Self {
             workouts: Vec::new(),
             stats: BasicStats::default(),
+            selected_exercise: None,
         }
     }
 }
@@ -32,17 +37,15 @@ impl App for MyApp {
     fn update(&mut self, ctx: &egui::Context, _frame: &mut Frame) {
         egui::CentralPanel::default().show(ctx, |ui| {
             if ui.button("Load CSV").clicked() {
-                if let Some(path) = FileDialog::new()
-                    .add_filter("CSV", &["csv"])
-                    .pick_file()
-                {
+                if let Some(path) = FileDialog::new().add_filter("CSV", &["csv"]).pick_file() {
                     if let Ok(file) = File::open(path) {
                         let mut rdr = csv::Reader::from_reader(file);
-                        self.workouts = rdr
-                            .deserialize()
-                            .filter_map(|res| res.ok())
-                            .collect();
+                        self.workouts = rdr.deserialize().filter_map(|res| res.ok()).collect();
                         self.stats = compute_stats(&self.workouts);
+                        if self.selected_exercise.is_none() {
+                            self.selected_exercise =
+                                unique_exercises(&self.workouts).into_iter().next();
+                        }
                     }
                 }
             }
@@ -50,13 +53,51 @@ impl App for MyApp {
             if !self.workouts.is_empty() {
                 ui.heading("Workout Statistics");
                 ui.label(format!("Total workouts: {}", self.stats.total_workouts));
-                ui.label(format!("Avg sets/workout: {:.2}", self.stats.avg_sets_per_workout));
+                ui.label(format!(
+                    "Avg sets/workout: {:.2}",
+                    self.stats.avg_sets_per_workout
+                ));
                 ui.label(format!("Avg reps/set: {:.2}", self.stats.avg_reps_per_set));
-                ui.label(format!("Avg days between: {:.2}", self.stats.avg_days_between));
+                ui.label(format!(
+                    "Avg days between: {:.2}",
+                    self.stats.avg_days_between
+                ));
                 if let Some(ref ex) = self.stats.most_common_exercise {
                     ui.label(format!("Most common exercise: {}", ex));
                 }
                 ui.separator();
+
+                let exercises = unique_exercises(&self.workouts);
+                if self.selected_exercise.is_none() {
+                    self.selected_exercise = exercises.first().cloned();
+                }
+                ui.horizontal(|ui| {
+                    ui.label("Exercise:");
+                    egui::ComboBox::from_id_source("exercise_combo")
+                        .selected_text(
+                            self.selected_exercise
+                                .as_ref()
+                                .cloned()
+                                .unwrap_or_else(|| "".to_string()),
+                        )
+                        .show_ui(ui, |ui| {
+                            for ex in &exercises {
+                                ui.selectable_value(
+                                    &mut self.selected_exercise,
+                                    Some(ex.clone()),
+                                    ex,
+                                );
+                            }
+                        });
+                });
+
+                if let Some(ref ex) = self.selected_exercise {
+                    Plot::new("exercise_plot").show(ui, |plot_ui| {
+                        plot_ui.line(weight_over_time_line(&self.workouts, ex));
+                        plot_ui.line(estimated_1rm_line(&self.workouts, ex));
+                        plot_ui.bar_chart(sets_per_day_bar(&self.workouts, Some(ex)));
+                    });
+                }
             }
 
             ui.heading("Loaded Workouts");

--- a/src/plotting.rs
+++ b/src/plotting.rs
@@ -1,0 +1,63 @@
+use chrono::{Datelike, NaiveDate};
+use egui_plot::{Bar, BarChart, Line, PlotPoints};
+
+use crate::WorkoutEntry;
+
+/// Generate a line plot of weight over time for a given exercise.
+pub fn weight_over_time_line(entries: &[WorkoutEntry], exercise: &str) -> Line {
+    let points: Vec<[f64; 2]> = entries
+        .iter()
+        .filter(|e| e.exercise == exercise)
+        .filter_map(|e| {
+            NaiveDate::parse_from_str(&e.date, "%Y-%m-%d")
+                .ok()
+                .map(|d| [d.num_days_from_ce() as f64, e.weight as f64])
+        })
+        .collect();
+    Line::new(PlotPoints::from(points)).name("Weight")
+}
+
+/// Generate a line plot of estimated 1RM over time for a given exercise.
+/// Uses the Epley formula: weight * (1 + reps / 30).
+pub fn estimated_1rm_line(entries: &[WorkoutEntry], exercise: &str) -> Line {
+    let points: Vec<[f64; 2]> = entries
+        .iter()
+        .filter(|e| e.exercise == exercise)
+        .filter_map(|e| {
+            NaiveDate::parse_from_str(&e.date, "%Y-%m-%d")
+                .ok()
+                .map(|d| {
+                    let est = e.weight as f64 * (1.0 + e.reps as f64 / 30.0);
+                    [d.num_days_from_ce() as f64, est]
+                })
+        })
+        .collect();
+    Line::new(PlotPoints::from(points)).name("1RM Est")
+}
+
+/// Create a bar chart of sets per day for an optional exercise.
+pub fn sets_per_day_bar(entries: &[WorkoutEntry], exercise: Option<&str>) -> BarChart {
+    let mut map: std::collections::BTreeMap<NaiveDate, usize> = std::collections::BTreeMap::new();
+    for e in entries {
+        if exercise.map(|ex| ex == e.exercise).unwrap_or(true) {
+            if let Ok(d) = NaiveDate::parse_from_str(&e.date, "%Y-%m-%d") {
+                *map.entry(d).or_insert(0) += 1;
+            }
+        }
+    }
+    let bars: Vec<Bar> = map
+        .into_iter()
+        .enumerate()
+        .map(|(idx, (_d, count))| Bar::new(idx as f64, count as f64))
+        .collect();
+    BarChart::new(bars).name("Sets")
+}
+
+/// Return a sorted list of unique exercises found in the data.
+pub fn unique_exercises(entries: &[WorkoutEntry]) -> Vec<String> {
+    let mut set = std::collections::BTreeSet::new();
+    for e in entries {
+        set.insert(e.exercise.clone());
+    }
+    set.into_iter().collect()
+}


### PR DESCRIPTION
## Summary
- add `egui_plot` as a dependency
- add a `plotting` module with helpers returning `Line`/`Bar` plots
- integrate exercise selection and plots into the UI

## Testing
- `cargo test --quiet`
- `cargo build --quiet`


------
https://chatgpt.com/codex/tasks/task_e_688507c19f008332b2b8d6b12d5559d8