### PR TITLE
Add logging and format helper

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -11,6 +11,8 @@ dependencies = [
  "eframe",
  "egui",
  "egui_plot",
+ "env_logger",
+ "log",
  "rfd",
  "serde",
 ]
@@ -176,6 +178,56 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "819e7219dbd41043ac279b19830f2efc897156490d7fd6ea916720117ee66311"
 dependencies = [
  "libc",
+]
+
+[[package]]
+name = "anstream"
+version = "0.6.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "301af1932e46185686725e0fad2f8f2aa7da69dd70bf6ecc44d6b703844a3933"
+dependencies = [
+ "anstyle",
+ "anstyle-parse",
+ "anstyle-query",
+ "anstyle-wincon",
+ "colorchoice",
+ "is_terminal_polyfill",
+ "utf8parse",
+]
+
+[[package]]
+name = "anstyle"
+version = "1.0.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "862ed96ca487e809f1c8e5a8447f6ee2cf102f846893800b20cebdf541fc6bbd"
+
+[[package]]
+name = "anstyle-parse"
+version = "0.2.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4e7644824f0aa2c7b9384579234ef10eb7efb6a0deb83f9630a49594dd9c15c2"
+dependencies = [
+ "utf8parse",
+]
+
+[[package]]
+name = "anstyle-query"
+version = "1.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6c8bdeb6047d8983be085bab0ba1472e6dc604e7041dbf6fcd5e71523014fae9"
+dependencies = [
+ "windows-sys 0.59.0",
+]
+
+[[package]]
+name = "anstyle-wincon"
+version = "3.0.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "403f75924867bb1033c59fbf0797484329750cfbe3c4325cd33127941fabc882"
+dependencies = [
+ "anstyle",
+ "once_cell_polyfill",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -823,6 +875,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3d7b894f5411737b7867f4827955924d7c254fc9f4d91a6aad6b097804b1018b"
 
 [[package]]
+name = "colorchoice"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b05b61dc5112cbb17e4b6cd61790d9845d13888356391624cbe7e41efeac1e75"
+
+[[package]]
 name = "com"
 version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1195,6 +1253,29 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.104",
+]
+
+[[package]]
+name = "env_filter"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "186e05a59d4c50738528153b83b0b0194d3a29507dfec16eccd4b342903397d0"
+dependencies = [
+ "log",
+ "regex",
+]
+
+[[package]]
+name = "env_logger"
+version = "0.11.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "13c863f0904021b108aa8b2f55046443e6b1ebde8fd4a15c399893aae4fa069f"
+dependencies = [
+ "anstream",
+ "anstyle",
+ "env_filter",
+ "jiff",
+ "log",
 ]
 
 [[package]]
@@ -1865,10 +1946,40 @@ dependencies = [
 ]
 
 [[package]]
+name = "is_terminal_polyfill"
+version = "1.70.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7943c866cc5cd64cbc25b2e01621d07fa8eb2a1a23160ee81ce38704e97b8ecf"
+
+[[package]]
 name = "itoa"
 version = "1.0.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4a5f13b858c8d314ee3e8f639011f7ccefe71f97f96e50151fb991f267928e2c"
+
+[[package]]
+name = "jiff"
+version = "0.2.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "be1f93b8b1eb69c77f24bbb0afdf66f54b632ee39af40ca21c4365a1d7347e49"
+dependencies = [
+ "jiff-static",
+ "log",
+ "portable-atomic",
+ "portable-atomic-util",
+ "serde",
+]
+
+[[package]]
+name = "jiff-static"
+version = "0.2.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "03343451ff899767262ec32146f6d559dd759fdadf42ff0e227c7c48f72594b4"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.104",
+]
 
 [[package]]
 name = "jni"
@@ -2359,6 +2470,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "42f5e15c9953c5e4ccceeb2e7382a716482c34515315f7b03532b8b4e8393d2d"
 
 [[package]]
+name = "once_cell_polyfill"
+version = "1.70.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4895175b425cb1f87721b59f0f286c2092bd4af812243672510e1ac53e2e0ad"
+
+[[package]]
 name = "orbclient"
 version = "0.3.48"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2504,6 +2621,21 @@ name = "pollster"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "22686f4785f02a4fcc856d3b3bb19bf6c8160d103f7a99cc258bddd0251dc7f2"
+
+[[package]]
+name = "portable-atomic"
+version = "1.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f84267b20a16ea918e43c6a88433c2d54fa145c92a811b5b047ccbe153674483"
+
+[[package]]
+name = "portable-atomic-util"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d8a2f0d8d040d7848a709caf78912debcc3f33ee4b3cac47d73d1e1069e83507"
+dependencies = [
+ "portable-atomic",
+]
 
 [[package]]
 name = "potential_utf"
@@ -3242,6 +3374,12 @@ name = "utf8_iter"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6c140620e7ffbb22c2dee59cafe6084a59b5ffc27a8859a5f0d494b5d52b6be"
+
+[[package]]
+name = "utf8parse"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
 
 [[package]]
 name = "version_check"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,3 +11,5 @@ serde = { version = "1", features = ["derive"] }
 chrono = "0.4"
 rfd = "0.14"
 egui_plot = "0.27"
+log = "0.4"
+env_logger = "0.11"

--- a/src/analysis.rs
+++ b/src/analysis.rs
@@ -16,10 +16,17 @@ fn parse_date(date: &str) -> Option<NaiveDate> {
     NaiveDate::parse_from_str(date, "%Y-%m-%d").ok()
 }
 
+/// Format the status message shown after loading a CSV file.
+pub fn format_load_message(entries: usize, filename: &str) -> String {
+    format!("Loaded {} entries from {}", entries, filename)
+}
+
 pub fn compute_stats(entries: &[WorkoutEntry]) -> BasicStats {
     if entries.is_empty() {
         return BasicStats::default();
     }
+
+    log::info!("Computing statistics for {} entries", entries.len());
 
     // Map date -> sets count
     let mut sets_per_day: HashMap<NaiveDate, usize> = HashMap::new();
@@ -112,5 +119,11 @@ mod tests {
         assert!((stats.avg_reps_per_set - 5.0).abs() < 1e-6);
         assert!((stats.avg_days_between - 2.0).abs() < 1e-6); // (2 + 2)/2
         assert_eq!(stats.most_common_exercise.as_deref(), Some("Squat"));
+    }
+
+    #[test]
+    fn test_format_load_message() {
+        let msg = format_load_message(10, "workouts.csv");
+        assert_eq!(msg, "Loaded 10 entries from workouts.csv");
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -5,8 +5,10 @@ use serde::Deserialize;
 use std::fs::File;
 use std::time::{Duration, Instant};
 
+use log::info;
+
 mod analysis;
-use analysis::{BasicStats, compute_stats};
+use analysis::{format_load_message, BasicStats, compute_stats};
 mod plotting;
 use plotting::{estimated_1rm_line, sets_per_day_bar, unique_exercises, weight_over_time_line};
 
@@ -74,6 +76,7 @@ impl App for MyApp {
                     if let Ok(file) = File::open(&path) {
                         let mut rdr = csv::Reader::from_reader(file);
                         self.workouts = rdr.deserialize().filter_map(|res| res.ok()).collect();
+                        info!("Loaded {} entries from {}", self.workouts.len(), filename);
                         self.stats = compute_stats(&self.workouts);
                         if self.selected_exercise.is_none() {
                             self.selected_exercise =
@@ -147,11 +150,7 @@ impl App for MyApp {
                 egui::Area::new(egui::Id::new("load_toast"))
                     .anchor(egui::Align2::RIGHT_TOP, [-10.0, 10.0])
                     .show(ctx, |ui| {
-                        ui.label(format!(
-                            "Loaded {} entries from {}",
-                            self.workouts.len(),
-                            file
-                        ));
+                        ui.label(format_load_message(self.workouts.len(), file));
                     });
             } else {
                 self.toast_start = None;
@@ -161,6 +160,7 @@ impl App for MyApp {
 }
 
 fn main() -> eframe::Result<()> {
+    env_logger::init();
     let options = NativeOptions::default();
     eframe::run_native(
         "Multi Hevy Workout Dashboard",


### PR DESCRIPTION
## Summary
- include `log` and `env_logger` crates
- log when CSV files are loaded and when statistics are computed
- show toast using new `format_load_message` helper
- initialize logging in `main`
- add unit tests for the helper

## Testing
- `cargo test --quiet`
- `cargo check --quiet`


------
https://chatgpt.com/codex/tasks/task_e_688515b562448332abdd19a347c8c89e