### PR TITLE
Add persistent user settings

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8,6 +8,7 @@ version = "0.1.0"
 dependencies = [
  "chrono",
  "csv",
+ "dirs-next",
  "eframe",
  "egui",
  "egui_extras",
@@ -17,6 +18,7 @@ dependencies = [
  "log",
  "rfd",
  "serde",
+ "serde_json",
 ]
 
 [[package]]
@@ -828,6 +830,7 @@ dependencies = [
  "iana-time-zone",
  "js-sys",
  "num-traits",
+ "serde",
  "wasm-bindgen",
  "windows-link",
 ]
@@ -1088,6 +1091,27 @@ checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
 dependencies = [
  "block-buffer",
  "crypto-common",
+]
+
+[[package]]
+name = "dirs-next"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b98cf8ebf19c3d1b223e151f99a4f9f0690dca41414773390fc824184ac833e1"
+dependencies = [
+ "cfg-if",
+ "dirs-sys-next",
+]
+
+[[package]]
+name = "dirs-sys-next"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4ebda144c4fe02d1f7ea1a7d9641b6fc6b580adcfa024ae48797ecdeb6825b4d"
+dependencies = [
+ "libc",
+ "redox_users",
+ "winapi",
 ]
 
 [[package]]
@@ -3020,6 +3044,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "redox_users"
+version = "0.4.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba009ff324d1fc1b900bd1fdb31564febe58a8ccc8a6fdbb93b543d33b13ca43"
+dependencies = [
+ "getrandom 0.2.16",
+ "libredox",
+ "thiserror",
+]
+
+[[package]]
 name = "regex"
 version = "1.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3193,6 +3228,18 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.104",
+]
+
+[[package]]
+name = "serde_json"
+version = "1.0.141"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "30b9eff21ebe718216c6ec64e1d9ac57087aad11efc64e32002bce4a0d4c03d3"
+dependencies = [
+ "itoa",
+ "memchr",
+ "ryu",
+ "serde",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,10 +8,12 @@ eframe = "0.27"
 egui = "0.27"
 csv = "1"
 serde = { version = "1", features = ["derive"] }
-chrono = "0.4"
+chrono = { version = "0.4", features = ["serde"] }
 rfd = "0.14"
 egui_plot = "0.27"
 log = "0.4"
 env_logger = "0.11"
 egui_extras = { version = "0.27", features = ["chrono"] }
 image = "0.24"
+dirs-next = "2"
+serde_json = "1"

--- a/src/plotting.rs
+++ b/src/plotting.rs
@@ -2,9 +2,10 @@ use chrono::{Datelike, NaiveDate};
 use egui_plot::{Bar, BarChart, Line, PlotPoints};
 
 use crate::WorkoutEntry;
+use serde::{Deserialize, Serialize};
 
 /// Available formulas for estimating a one-rep max.
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
 pub enum OneRmFormula {
     /// Epley formula: `weight * (1 + reps / 30)`.
     Epley,


### PR DESCRIPTION
## Summary
- store `Settings` in `dirs_next` config directory
- load saved settings on startup and write changes out
- derive serde support for `OneRmFormula`
- test that `Settings` JSON round-trips

## Testing
- `cargo test`

 