### PR TITLE
Add rustdoc for analysis and plotting

### DIFF
--- a/src/analysis.rs
+++ b/src/analysis.rs
@@ -4,6 +4,7 @@ use crate::plotting::OneRmFormula;
 use chrono::NaiveDate;
 use std::collections::HashMap;
 
+/// Summary statistics about a workout log.
 #[derive(Debug, Default, PartialEq)]
 pub struct BasicStats {
     pub total_workouts: usize,
@@ -22,7 +23,11 @@ pub struct ExerciseStats {
     pub best_est_1rm: Option<f32>,
 }
 
-/// Return a map from exercise name to aggregated statistics.
+/// Aggregate per-exercise statistics from a slice of workout entries.
+///
+/// The data can be limited to an optional date range. Invalid dates are
+/// skipped. For each exercise all sets are combined and the best estimated
+/// one-rep max is calculated using the provided [`OneRmFormula`].
 pub fn aggregate_exercise_stats(
     entries: &[WorkoutEntry],
     formula: OneRmFormula,
@@ -65,11 +70,18 @@ fn parse_date(date: &str) -> Option<NaiveDate> {
     NaiveDate::parse_from_str(date, "%Y-%m-%d").ok()
 }
 
-/// Format the status message shown after loading a CSV file.
+/// Format a user facing message after successfully loading a CSV file.
+///
+/// The returned string includes the number of parsed entries and the file name
+/// and can be used in status bars or log output.
 pub fn format_load_message(entries: usize, filename: &str) -> String {
     format!("Loaded {} entries from {}", entries, filename)
 }
 
+/// Compute overall statistics for the loaded workout entries.
+///
+/// Only entries within the optional `start` and `end` date range are included.
+/// If no valid workout dates are found an empty [`BasicStats`] is returned.
 pub fn compute_stats(
     entries: &[WorkoutEntry],
     start: Option<NaiveDate>,

--- a/src/plotting.rs
+++ b/src/plotting.rs
@@ -14,6 +14,9 @@ pub enum OneRmFormula {
 }
 
 /// Generate a line plot of weight over time for a given exercise.
+///
+/// Only entries for `exercise` within the optional date range are used. Invalid
+/// dates are ignored.
 pub fn weight_over_time_line(
     entries: &[WorkoutEntry],
     exercise: &str,
@@ -33,11 +36,12 @@ pub fn weight_over_time_line(
     Line::new(PlotPoints::from(points)).name("Weight")
 }
 
-/// Generate a line plot of estimated 1RM over time for a given exercise.
+/// Generate a line plot of the estimated one-rep max over time for a given
+/// exercise.
 ///
-/// * `entries` - All workout entries loaded from the CSV.
-/// * `exercise` - Name of the exercise to plot.
-/// * `formula` - The one-rep max estimation formula to use.
+/// The estimation is performed for each set using the supplied
+/// [`OneRmFormula`]. Only sets for `exercise` within the optional date range are
+/// included.
 pub fn estimated_1rm_line(
     entries: &[WorkoutEntry],
     exercise: &str,
@@ -69,7 +73,10 @@ pub fn estimated_1rm_line(
     Line::new(PlotPoints::from(points)).name("1RM Est")
 }
 
-/// Create a bar chart of sets per day for an optional exercise.
+/// Create a bar chart of how many sets were performed on each day.
+///
+/// When `exercise` is `Some`, only sets of that exercise are counted. Entries
+/// outside of the optional date range or with invalid dates are skipped.
 pub fn sets_per_day_bar(
     entries: &[WorkoutEntry],
     exercise: Option<&str>,
@@ -113,7 +120,10 @@ fn training_volume_points(
         .collect()
 }
 
-/// Create a line plot of training volume per day.
+/// Create a line plot of total training volume per day.
+///
+/// Training volume is calculated as `weight * reps` for each set. Only entries
+/// within the optional date range are considered.
 pub fn training_volume_line(
     entries: &[WorkoutEntry],
     start: Option<NaiveDate>,
@@ -124,6 +134,9 @@ pub fn training_volume_line(
 }
 
 /// Return a sorted list of unique exercises found in the data.
+///
+/// Only entries whose dates fall inside the optional range are inspected. The
+/// resulting vector is sorted alphabetically.
 pub fn unique_exercises(
     entries: &[WorkoutEntry],
     start: Option<NaiveDate>,


### PR DESCRIPTION
## Summary
- document public types and functions in `analysis` and `plotting`
- run `cargo doc` to ensure docs compile

## Testing
- `cargo doc --no-deps`
- `cargo test`

 