### PR TITLE
Add support for extended Hevy CSV format

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,14 +24,20 @@ On launch you will see a window with a **Load CSV** button.
 
 ## Hevy CSV Example
 
-Hevy exports workouts as a CSV where each row contains the workout date, exercise name, weight and reps. Example:
+Hevy exports workouts as a CSV. The dashboard expects the extended export which
+contains columns like the workout start time and exercise information. A snippet
+looks like:
 
 ```csv
-date,exercise,weight,reps
-2024-01-01,Squat,100,5
-2024-01-01,Bench,80,5
-2024-01-03,Squat,105,5
+"title","start_time","end_time","description","exercise_title","superset_id","exercise_notes","set_index","set_type","weight_lbs","reps","distance_miles","duration_seconds","rpe"
+"Week 12 - Lower - Strength","26 Jul 2025, 07:06","26 Jul 2025, 08:11","...","Lying Leg Curl (Machine)",,"",0,"warmup",100,10,,,
 ```
+
+Each row represents a single set. All columns are parsed and stored:
+`title`, `start_time`, `end_time`, `description`, `exercise_title`, `superset_id`,
+`exercise_notes`, `set_index`, `set_type`, `weight_lbs`, `reps`,
+`distance_miles`, `duration_seconds` and `rpe`. The graphs are generated from
+the workout date, exercise name, weight and reps.
 
 ## Features
 

--- a/src/analysis.rs
+++ b/src/analysis.rs
@@ -151,6 +151,7 @@ pub fn compute_stats(
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::RawWorkoutRow;
 
     fn sample_entries() -> Vec<WorkoutEntry> {
         vec![
@@ -159,24 +160,28 @@ mod tests {
                 exercise: "Squat".into(),
                 weight: 100.0,
                 reps: 5,
+                raw: RawWorkoutRow::default(),
             },
             WorkoutEntry {
                 date: "2024-01-01".into(),
                 exercise: "Bench".into(),
                 weight: 80.0,
                 reps: 5,
+                raw: RawWorkoutRow::default(),
             },
             WorkoutEntry {
                 date: "2024-01-03".into(),
                 exercise: "Squat".into(),
                 weight: 105.0,
                 reps: 5,
+                raw: RawWorkoutRow::default(),
             },
             WorkoutEntry {
                 date: "2024-01-05".into(),
                 exercise: "Deadlift".into(),
                 weight: 120.0,
                 reps: 5,
+                raw: RawWorkoutRow::default(),
             },
         ]
     }
@@ -188,12 +193,14 @@ mod tests {
                 exercise: "Squat".into(),
                 weight: 100.0,
                 reps: 5,
+                raw: RawWorkoutRow::default(),
             },
             WorkoutEntry {
                 date: "2024-13-01".into(), // invalid month
                 exercise: "Bench".into(),
                 weight: 80.0,
                 reps: 5,
+                raw: RawWorkoutRow::default(),
             },
         ]
     }

--- a/src/plotting.rs
+++ b/src/plotting.rs
@@ -157,6 +157,7 @@ pub fn unique_exercises(
 mod tests {
     use super::*;
     use egui_plot::{PlotGeometry, PlotItem};
+    use crate::RawWorkoutRow;
 
     fn sample_entries() -> Vec<WorkoutEntry> {
         vec![
@@ -165,18 +166,21 @@ mod tests {
                 exercise: "Squat".into(),
                 weight: 100.0,
                 reps: 5,
+                raw: RawWorkoutRow::default(),
             },
             WorkoutEntry {
                 date: "2024-01-01".into(),
                 exercise: "Bench".into(),
                 weight: 80.0,
                 reps: 5,
+                raw: RawWorkoutRow::default(),
             },
             WorkoutEntry {
                 date: "2024-01-03".into(),
                 exercise: "Squat".into(),
                 weight: 105.0,
                 reps: 5,
+                raw: RawWorkoutRow::default(),
             },
         ]
     }


### PR DESCRIPTION
## Summary
- update README example to show extended Hevy CSV
- add parser for extended CSV export
- hook up new parser when loading CSV files
- test CSV parsing of new format
- capture all fields from CSV and store them in entries

## Testing
- `cargo test --quiet`


------
https://chatgpt.com/codex/tasks/task_e_68855231237883328a4e9feaed8b7f28