### PR TITLE
Add pop-out plot window toggle

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -187,6 +187,7 @@ struct MyApp {
     settings: Settings,
     show_settings: bool,
     show_entries: bool,
+    show_plot_window: bool,
     sort_column: SortColumn,
     sort_ascending: bool,
     capture_rect: Option<egui::Rect>,
@@ -206,6 +207,7 @@ impl Default for MyApp {
             settings: Settings::load(),
             show_settings: false,
             show_entries: false,
+            show_plot_window: false,
             sort_column: SortColumn::Date,
             sort_ascending: true,
             capture_rect: None,
@@ -325,6 +327,159 @@ impl MyApp {
             .iter()
             .filter(|e| self.entry_matches_filters(e))
             .collect()
+    }
+
+    fn draw_plot(
+        &self,
+        ctx: &egui::Context,
+        ui: &mut egui::Ui,
+        filtered: &[WorkoutEntry],
+        sel: &[String],
+    ) -> egui_plot::PlotResponse<()> {
+        let mut all_points: Vec<[f64; 2]> = Vec::new();
+        let mut highlight: Option<[f64; 2]> = None;
+        let x_axis = self.settings.x_axis;
+        let plot_resp = Plot::new("exercise_plot")
+            .x_axis_formatter(move |mark, _chars, _| {
+                if x_axis == XAxis::Date {
+                    NaiveDate::from_num_days_from_ce_opt(mark.value.round() as i32)
+                        .map(|d| d.format("%Y-%m-%d").to_string())
+                        .unwrap_or_else(|| format!("{:.0}", mark.value))
+                } else {
+                    format!("{:.0}", mark.value)
+                }
+            })
+            .show(ui, |plot_ui| {
+                let pointer = plot_ui.pointer_coordinate();
+                if self.settings.show_weight {
+                    let ma = if self.settings.show_smoothed {
+                        Some(self.settings.ma_window)
+                    } else {
+                        None
+                    };
+                    for lw in weight_over_time_line(
+                        filtered,
+                        sel,
+                        self.settings.start_date,
+                        self.settings.end_date,
+                        self.settings.x_axis,
+                        self.settings.y_axis,
+                        self.settings.weight_unit,
+                        ma,
+                    ) {
+                        for p in &lw.points {
+                            all_points.push(*p);
+                        }
+                        plot_ui.line(lw.line);
+                        if self.settings.highlight_max {
+                            if let Some(p) = lw.max_point {
+                                plot_ui.points(
+                                    Points::new(vec![p])
+                                        .shape(MarkerShape::Diamond)
+                                        .color(egui::Color32::RED)
+                                        .name("Max Weight"),
+                                );
+                            }
+                        }
+                    }
+                }
+                if self.settings.show_est_1rm {
+                    let ma = if self.settings.show_smoothed {
+                        Some(self.settings.ma_window)
+                    } else {
+                        None
+                    };
+                    for lr in estimated_1rm_line(
+                        filtered,
+                        sel,
+                        self.settings.one_rm_formula,
+                        self.settings.start_date,
+                        self.settings.end_date,
+                        self.settings.x_axis,
+                        self.settings.weight_unit,
+                        ma,
+                    ) {
+                        for p in &lr.points {
+                            all_points.push(*p);
+                        }
+                        plot_ui.line(lr.line);
+                        if self.settings.highlight_max {
+                            if let Some(p) = lr.max_point {
+                                plot_ui.points(
+                                    Points::new(vec![p])
+                                        .shape(MarkerShape::Circle)
+                                        .color(egui::Color32::BLUE)
+                                        .name("Max 1RM"),
+                                );
+                            }
+                        }
+                    }
+                }
+                if self.settings.show_volume {
+                    let ma = if self.settings.show_smoothed {
+                        Some(self.settings.ma_window)
+                    } else {
+                        None
+                    };
+                    for l in training_volume_line(
+                        filtered,
+                        self.settings.start_date,
+                        self.settings.end_date,
+                        self.settings.x_axis,
+                        self.settings.y_axis,
+                        self.settings.weight_unit,
+                        ma,
+                    ) {
+                        if let PlotGeometry::Points(pts) = l.geometry() {
+                            for p in pts {
+                                all_points.push([p.x, p.y]);
+                            }
+                        }
+                        plot_ui.line(l);
+                    }
+                }
+                if self.settings.show_sets {
+                    let ex_for_sets = if sel.len() == 1 {
+                        Some(sel[0].as_str())
+                    } else {
+                        None
+                    };
+                    plot_ui.bar_chart(sets_per_day_bar(
+                        filtered,
+                        ex_for_sets,
+                        self.settings.start_date,
+                        self.settings.end_date,
+                    ));
+                }
+
+                if let Some(ptr) = pointer {
+                    if let Some(p) = nearest_point(ptr, &all_points) {
+                        highlight = Some(p);
+                        plot_ui.points(
+                            Points::new(vec![p])
+                                .color(egui::Color32::YELLOW)
+                                .highlight(true)
+                                .name("Hovered"),
+                        );
+                    }
+                }
+            });
+
+        if let Some(p) = highlight {
+            if plot_resp.response.hovered() {
+                egui::show_tooltip_at_pointer(ctx, egui::Id::new("plot_tip"), |ui| {
+                    let x_text = match self.settings.x_axis {
+                        XAxis::Date => NaiveDate::from_num_days_from_ce(p[0] as i32)
+                            .format("%Y-%m-%d")
+                            .to_string(),
+                        XAxis::WorkoutIndex => format!("{}", p[0] as i64),
+                    };
+                    ui.label(format!("{x_text}: {:.2}", p[1]));
+                });
+            }
+        }
+
+        plot_resp
     }
 }
 
@@ -602,151 +757,13 @@ impl App for MyApp {
 
                 if !self.selected_exercises.is_empty() {
                     let sel: Vec<String> = self.selected_exercises.clone();
-                    let mut all_points: Vec<[f64; 2]> = Vec::new();
-                    let mut highlight: Option<[f64; 2]> = None;
-                    let x_axis = self.settings.x_axis;
-                    let plot_resp = Plot::new("exercise_plot")
-                        .x_axis_formatter(move |mark, _chars, _| {
-                            if x_axis == XAxis::Date {
-                                NaiveDate::from_num_days_from_ce_opt(mark.value.round() as i32)
-                                    .map(|d| d.format("%Y-%m-%d").to_string())
-                                    .unwrap_or_else(|| format!("{:.0}", mark.value))
-                            } else {
-                                format!("{:.0}", mark.value)
-                            }
-                        })
-                        .show(ui, |plot_ui| {
-                            let pointer = plot_ui.pointer_coordinate();
-                            if self.settings.show_weight {
-                                let ma = if self.settings.show_smoothed {
-                                    Some(self.settings.ma_window)
-                                } else {
-                                    None
-                                };
-                                for lw in weight_over_time_line(
-                                    &filtered,
-                                    &sel,
-                                    self.settings.start_date,
-                                    self.settings.end_date,
-                                    self.settings.x_axis,
-                                    self.settings.y_axis,
-                                    self.settings.weight_unit,
-                                    ma,
-                                ) {
-                                    for p in &lw.points {
-                                        all_points.push(*p);
-                                    }
-                                    plot_ui.line(lw.line);
-                                    if self.settings.highlight_max {
-                                        if let Some(p) = lw.max_point {
-                                            plot_ui.points(
-                                                Points::new(vec![p])
-                                                    .shape(MarkerShape::Diamond)
-                                                    .color(egui::Color32::RED)
-                                                    .name("Max Weight"),
-                                            );
-                                        }
-                                    }
-                                }
-                            }
-                            if self.settings.show_est_1rm {
-                                let ma = if self.settings.show_smoothed {
-                                    Some(self.settings.ma_window)
-                                } else {
-                                    None
-                                };
-                                for lr in estimated_1rm_line(
-                                    &filtered,
-                                    &sel,
-                                    self.settings.one_rm_formula,
-                                    self.settings.start_date,
-                                    self.settings.end_date,
-                                    self.settings.x_axis,
-                                    self.settings.weight_unit,
-                                    ma,
-                                ) {
-                                    for p in &lr.points {
-                                        all_points.push(*p);
-                                    }
-                                    plot_ui.line(lr.line);
-                                    if self.settings.highlight_max {
-                                        if let Some(p) = lr.max_point {
-                                            plot_ui.points(
-                                                Points::new(vec![p])
-                                                    .shape(MarkerShape::Circle)
-                                                    .color(egui::Color32::BLUE)
-                                                    .name("Max 1RM"),
-                                            );
-                                        }
-                                    }
-                                }
-                            }
-                            if self.settings.show_volume {
-                                let ma = if self.settings.show_smoothed {
-                                    Some(self.settings.ma_window)
-                                } else {
-                                    None
-                                };
-                                for l in training_volume_line(
-                                    &filtered,
-                                    self.settings.start_date,
-                                    self.settings.end_date,
-                                    self.settings.x_axis,
-                                    self.settings.y_axis,
-                                    self.settings.weight_unit,
-                                    ma,
-                                ) {
-                                    if let PlotGeometry::Points(pts) = l.geometry() {
-                                        for p in pts {
-                                            all_points.push([p.x, p.y]);
-                                        }
-                                    }
-                                    plot_ui.line(l);
-                                }
-                            }
-                            if self.settings.show_sets {
-                                let ex_for_sets = if sel.len() == 1 {
-                                    Some(sel[0].as_str())
-                                } else {
-                                    None
-                                };
-                                plot_ui.bar_chart(sets_per_day_bar(
-                                    &filtered,
-                                    ex_for_sets,
-                                    self.settings.start_date,
-                                    self.settings.end_date,
-                                ));
-                            }
-
-                            if let Some(ptr) = pointer {
-                                if let Some(p) = nearest_point(ptr, &all_points) {
-                                    highlight = Some(p);
-                                    plot_ui.points(
-                                        Points::new(vec![p])
-                                            .color(egui::Color32::YELLOW)
-                                            .highlight(true)
-                                            .name("Hovered"),
-                                    );
-                                }
-                            }
-                        });
+                    let plot_resp = self.draw_plot(ctx, ui, &filtered, &sel);
                     if ui.button("Save Plot").clicked() {
                         self.capture_rect = Some(plot_resp.response.rect);
                         ctx.send_viewport_cmd(egui::ViewportCommand::Screenshot);
                     }
-
-                    if let Some(p) = highlight {
-                        if plot_resp.response.hovered() {
-                            egui::show_tooltip_at_pointer(ctx, egui::Id::new("plot_tip"), |ui| {
-                                let x_text = match self.settings.x_axis {
-                                    XAxis::Date => NaiveDate::from_num_days_from_ce(p[0] as i32)
-                                        .format("%Y-%m-%d")
-                                        .to_string(),
-                                    XAxis::WorkoutIndex => format!("{}", p[0] as i64),
-                                };
-                                ui.label(format!("{x_text}: {:.2}", p[1]));
-                            });
-                        }
+                    if ui.button("Plot Window").clicked() {
+                        self.show_plot_window = !self.show_plot_window;
                     }
                 }
             }
@@ -869,6 +886,25 @@ impl App for MyApp {
             self.table_filter = table_filter;
             self.sort_column = sort_column;
             self.sort_ascending = sort_ascending;
+        }
+
+        if self.show_plot_window {
+            let filtered = self.filtered_entries();
+            if !self.selected_exercises.is_empty() {
+                let sel: Vec<String> = self.selected_exercises.clone();
+                let mut open = self.show_plot_window;
+                egui::Window::new("Plot Window")
+                    .open(&mut open)
+                    .vscroll(true)
+                    .show(ctx, |ui| {
+                        let plot_resp = self.draw_plot(ctx, ui, &filtered, &sel);
+                        if ui.button("Save Plot").clicked() {
+                            self.capture_rect = Some(plot_resp.response.rect);
+                            ctx.send_viewport_cmd(egui::ViewportCommand::Screenshot);
+                        }
+                    });
+                self.show_plot_window = open;
+            }
         }
 
         if self.show_settings {


### PR DESCRIPTION
## Summary
- allow toggling a separate plot window
- reuse the main plot rendering function inside the new window

## Testing
- `cargo fmt --all`
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_68857f5f83408332a1988ec8b71b6b75