### PR TITLE
Add muscle group list helper and ComboBox filter

### DIFF
--- a/src/body_parts.rs
+++ b/src/body_parts.rs
@@ -216,3 +216,13 @@ pub fn info_for(exercise: &str) -> Option<&'static ExerciseInfo> {
 pub fn body_part_for(exercise: &str) -> Option<&'static str> {
     info_for(exercise).map(|i| i.primary)
 }
+
+/// Return a sorted list of all unique primary muscle groups.
+pub fn primary_muscle_groups() -> Vec<&'static str> {
+    use std::collections::BTreeSet;
+    let mut set = BTreeSet::new();
+    for info in EXERCISES.values() {
+        set.insert(info.primary);
+    }
+    set.into_iter().collect()
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -1229,13 +1229,21 @@ impl App for MyApp {
                     });
                     ui.horizontal(|ui| {
                         ui.label("Body part:");
-                        let mut bp = self.settings.body_part_filter.clone().unwrap_or_default();
-                        if ui.text_edit_singleline(&mut bp).changed() {
-                            self.settings.body_part_filter = if bp.trim().is_empty() {
-                                None
-                            } else {
-                                Some(bp)
-                            };
+                        let prev = self.settings.body_part_filter.clone();
+                        let parts = body_parts::primary_muscle_groups();
+                        egui::ComboBox::from_id_source("body_part_filter_combo")
+                            .selected_text(prev.as_deref().unwrap_or("All"))
+                            .show_ui(ui, |ui| {
+                                ui.selectable_value(&mut self.settings.body_part_filter, None::<String>, "All");
+                                for p in parts {
+                                    ui.selectable_value(
+                                        &mut self.settings.body_part_filter,
+                                        Some(p.to_string()),
+                                        p,
+                                    );
+                                }
+                            });
+                        if prev != self.settings.body_part_filter {
                             self.settings_dirty = true;
                         }
                     });


### PR DESCRIPTION
## Summary
- provide helper to list unique primary muscle groups
- switch body part filter to a ComboBox using these groups

## Testing
- `cargo test --quiet`

------
https://chatgpt.com/codex/tasks/task_e_68860da8f9708332a62244d077056ac4