### PR TITLE
Add exercise type filter

### DIFF
--- a/src/body_parts.rs
+++ b/src/body_parts.rs
@@ -1,7 +1,8 @@
 use phf::phf_map;
+use serde::{Deserialize, Serialize};
 
 /// Type of exercise based on muscle engagement.
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
 pub enum ExerciseType {
     Compound,
     Isolation,
@@ -9,6 +10,14 @@ pub enum ExerciseType {
     Cardio,
     Plyometric,
 }
+
+pub const ALL_EXERCISE_TYPES: [ExerciseType; 5] = [
+    ExerciseType::Compound,
+    ExerciseType::Isolation,
+    ExerciseType::Isometric,
+    ExerciseType::Cardio,
+    ExerciseType::Plyometric,
+];
 
 /// Metadata about an exercise including its primary and secondary muscles.
 #[derive(Debug, Clone, Copy)]


### PR DESCRIPTION
## Summary
- allow filtering workouts by exercise type
- store/load the new `exercise_type_filter` in settings
- provide an exercise type combo box in the UI
- check the filter when matching entries
- update tests for settings roundtrip and filtering by type

## Testing
- `cargo test --quiet`

------
https://chatgpt.com/codex/tasks/task_e_688613a863348332b73a2c25b7162e96