### PR TITLE
update stats when date range changes

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -1334,10 +1334,24 @@ impl App for MyApp {
                         {
                             self.settings.start_date = Some(start);
                             self.settings_dirty = true;
+                            if !self.workouts.is_empty() {
+                                self.stats = compute_stats(
+                                    &self.workouts,
+                                    self.settings.start_date,
+                                    self.settings.end_date,
+                                );
+                            }
                         }
                         if self.settings.start_date.is_some() && ui.button("Clear").clicked() {
                             self.settings.start_date = None;
                             self.settings_dirty = true;
+                            if !self.workouts.is_empty() {
+                                self.stats = compute_stats(
+                                    &self.workouts,
+                                    self.settings.start_date,
+                                    self.settings.end_date,
+                                );
+                            }
                         }
                     });
                     ui.horizontal(|ui| {
@@ -1352,10 +1366,24 @@ impl App for MyApp {
                         {
                             self.settings.end_date = Some(end);
                             self.settings_dirty = true;
+                            if !self.workouts.is_empty() {
+                                self.stats = compute_stats(
+                                    &self.workouts,
+                                    self.settings.start_date,
+                                    self.settings.end_date,
+                                );
+                            }
                         }
                         if self.settings.end_date.is_some() && ui.button("Clear").clicked() {
                             self.settings.end_date = None;
                             self.settings_dirty = true;
+                            if !self.workouts.is_empty() {
+                                self.stats = compute_stats(
+                                    &self.workouts,
+                                    self.settings.start_date,
+                                    self.settings.end_date,
+                                );
+                            }
                         }
                     });
                     ui.horizontal(|ui| {


### PR DESCRIPTION
⁷## Summary
- recompute statistics whenever the start or end date is updated in settings

## Testing
- `cargo 