### PR TITLE
Show numeric trends

### DIFF
--- a/src/analysis.rs
+++ b/src/analysis.rs
@@ -2,7 +2,7 @@
 use crate::WorkoutEntry;
 use crate::body_parts::body_part_for;
 use crate::plotting::OneRmFormula;
-use chrono::{NaiveDate, Datelike};
+use chrono::{Datelike, NaiveDate};
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 
@@ -73,11 +73,13 @@ pub fn aggregate_exercise_stats(
                     _ => Some(est),
                 };
 
-                let t = d.num_days_from_ce() as f32;
-                trend_data
-                    .entry(e.exercise.clone())
-                    .or_default()
-                    .push((t, e.weight, e.weight * e.reps as f32));
+                // Scale the time axis so slope represents change per month
+                let t = d.num_days_from_ce() as f32 / 30.0;
+                trend_data.entry(e.exercise.clone()).or_default().push((
+                    t,
+                    e.weight,
+                    e.weight * e.reps as f32,
+                ));
             }
         }
     }

--- a/src/main.rs
+++ b/src/main.rs
@@ -469,11 +469,11 @@ impl MyApp {
         });
     }
 
-    fn trend_symbol(trend: Option<f32>) -> &'static str {
+    fn trend_value(trend: Option<f32>, factor: f32) -> String {
         match trend {
-            Some(t) if t > 0.0 => "\u{25B2}",
-            Some(t) if t < 0.0 => "\u{25BC}",
-            _ => "\u{2013}",
+            Some(t) if t > 0.0 => format!("+{:.1}", t * factor),
+            Some(t) if t < 0.0 => format!("\u{2013}{:.1}", (t * factor).abs()),
+            _ => "\u{2013}".to_owned(),
         }
     }
 
@@ -1250,8 +1250,8 @@ impl App for MyApp {
                                         } else {
                                             ui.label("-");
                                         }
-                                        ui.label(MyApp::trend_symbol(s.weight_trend));
-                                        ui.label(MyApp::trend_symbol(s.volume_trend));
+                                        ui.label(MyApp::trend_value(s.weight_trend, f));
+                                        ui.label(MyApp::trend_value(s.volume_trend, f));
                                         ui.end_row();
                                     }
                                 });


### PR DESCRIPTION
## Summary
- show weight and volume changes numerically
- scale trend calculation to reflect monthly change

## Testing
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_688677ef4f50833284bc34e6acd502e8