### PR TITLE
Add muscle mapping panel and top control bar

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -16,6 +16,7 @@ dependencies = [
  "env_logger",
  "image",
  "log",
+ "once_cell",
  "phf",
  "rfd",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,3 +19,4 @@ dirs-next = "2"
 serde_json = "1"
 phf = { version = "0.11", features = ["macros"] }
 ureq = { version = "2", features = ["json"] }
+once_cell = "1"

--- a/src/analysis.rs
+++ b/src/analysis.rs
@@ -125,7 +125,7 @@ pub fn aggregate_sets_by_body_part(
     for e in entries {
         if let (Some(bp), Some(d)) = (body_part_for(&e.exercise), parse_date(&e.date)) {
             if start.map_or(true, |s| d >= s) && end.map_or(true, |e2| d <= e2) {
-                *map.entry(bp.to_string()).or_insert(0) += 1;
+                *map.entry(bp).or_insert(0) += 1;
             }
         }
     }

--- a/src/exercise_mapping.rs
+++ b/src/exercise_mapping.rs
@@ -12,9 +12,8 @@ pub struct MuscleMapping {
     pub category: String,
 }
 
-static MAPPINGS: Lazy<Mutex<HashMap<String, MuscleMapping>>> = Lazy::new(|| {
-    Mutex::new(HashMap::new())
-});
+static MAPPINGS: Lazy<Mutex<HashMap<String, MuscleMapping>>> =
+    Lazy::new(|| Mutex::new(HashMap::new()));
 
 const FILE: &str = "exercise_mapping.json";
 

--- a/src/exercise_mapping.rs
+++ b/src/exercise_mapping.rs
@@ -1,0 +1,60 @@
+use once_cell::sync::Lazy;
+use serde::{Deserialize, Serialize};
+use std::collections::HashMap;
+use std::sync::Mutex;
+
+use dirs_next as dirs;
+
+#[derive(Debug, Clone, Serialize, Deserialize, Default)]
+pub struct MuscleMapping {
+    pub primary: String,
+    pub secondary: Vec<String>,
+    pub category: String,
+}
+
+static MAPPINGS: Lazy<Mutex<HashMap<String, MuscleMapping>>> = Lazy::new(|| {
+    Mutex::new(HashMap::new())
+});
+
+const FILE: &str = "exercise_mapping.json";
+
+fn path() -> Option<std::path::PathBuf> {
+    dirs::config_dir().map(|p| p.join(FILE))
+}
+
+pub fn load() {
+    if let Some(p) = path() {
+        if let Ok(data) = std::fs::read_to_string(&p) {
+            if let Ok(map) = serde_json::from_str::<HashMap<String, MuscleMapping>>(&data) {
+                *MAPPINGS.lock().unwrap() = map;
+            }
+        }
+    }
+}
+
+pub fn save() {
+    if let Some(p) = path() {
+        if let Some(parent) = p.parent() {
+            let _ = std::fs::create_dir_all(parent);
+        }
+        if let Ok(data) = serde_json::to_string_pretty(&*MAPPINGS.lock().unwrap()) {
+            let _ = std::fs::write(p, data);
+        }
+    }
+}
+
+pub fn get(ex: &str) -> Option<MuscleMapping> {
+    MAPPINGS.lock().unwrap().get(ex).cloned()
+}
+
+pub fn set(ex: String, map: MuscleMapping) {
+    MAPPINGS.lock().unwrap().insert(ex, map);
+}
+
+pub fn remove(ex: &str) {
+    MAPPINGS.lock().unwrap().remove(ex);
+}
+
+pub fn all() -> HashMap<String, MuscleMapping> {
+    MAPPINGS.lock().unwrap().clone()
+}


### PR DESCRIPTION
## Summary
- add exercise_mapping module for customizable muscle assignments
- extend body_parts to use custom mappings
- show persistent mapping editor window
- add top control bar with exercise selector and actions

## Testing
- `cargo check`
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_68881213044c8332b1fe788a11174583