### PR TITLE
Add more 1RM estimation formulas

### DIFF
--- a/src/analysis.rs
+++ b/src/analysis.rs
@@ -93,6 +93,21 @@ pub fn aggregate_exercise_stats(
                         }
                         e.weight * 36.0 / (37.0 - e.reps as f32)
                     }
+                    OneRmFormula::Lander => {
+                        let denom = 1.013 - 0.026_712_3 * e.reps as f32;
+                        if denom <= 0.0 {
+                            continue;
+                        }
+                        e.weight / denom
+                    }
+                    OneRmFormula::Lombardi => e.weight * (e.reps as f32).powf(0.10),
+                    OneRmFormula::Mayhew => {
+                        100.0 * e.weight / (52.2 + 41.9 * (-0.055 * e.reps as f32).exp())
+                    }
+                    OneRmFormula::OConner => e.weight * (1.0 + 0.025 * e.reps as f32),
+                    OneRmFormula::Wathan => {
+                        100.0 * e.weight / (48.8 + 53.8 * (-0.075 * e.reps as f32).exp())
+                    }
                 };
                 stats.best_est_1rm = match stats.best_est_1rm {
                     Some(current) if current >= est => Some(current),
@@ -187,6 +202,21 @@ pub fn personal_records(
                             continue;
                         }
                         e.weight * 36.0 / (37.0 - e.reps as f32)
+                    }
+                    OneRmFormula::Lander => {
+                        let denom = 1.013 - 0.026_712_3 * e.reps as f32;
+                        if denom <= 0.0 {
+                            continue;
+                        }
+                        e.weight / denom
+                    }
+                    OneRmFormula::Lombardi => e.weight * (e.reps as f32).powf(0.10),
+                    OneRmFormula::Mayhew => {
+                        100.0 * e.weight / (52.2 + 41.9 * (-0.055 * e.reps as f32).exp())
+                    }
+                    OneRmFormula::OConner => e.weight * (1.0 + 0.025 * e.reps as f32),
+                    OneRmFormula::Wathan => {
+                        100.0 * e.weight / (48.8 + 53.8 * (-0.075 * e.reps as f32).exp())
                     }
                 };
                 rec.best_est_1rm = match rec.best_est_1rm {

--- a/src/main.rs
+++ b/src/main.rs
@@ -2346,6 +2346,11 @@ impl App for MyApp {
                                                 .selected_text(match self.settings.one_rm_formula {
                                                     OneRmFormula::Epley => "Epley",
                                                     OneRmFormula::Brzycki => "Brzycki",
+                                                    OneRmFormula::Lander => "Lander",
+                                                    OneRmFormula::Lombardi => "Lombardi",
+                                                    OneRmFormula::Mayhew => "Mayhew",
+                                                    OneRmFormula::OConner => "O'Conner",
+                                                    OneRmFormula::Wathan => "Wathan",
                                                 })
                                                 .show_ui(ui, |ui| {
                                                     ui.selectable_value(
@@ -2357,6 +2362,31 @@ impl App for MyApp {
                                                         &mut self.settings.one_rm_formula,
                                                         OneRmFormula::Brzycki,
                                                         "Brzycki",
+                                                    );
+                                                    ui.selectable_value(
+                                                        &mut self.settings.one_rm_formula,
+                                                        OneRmFormula::Lander,
+                                                        "Lander",
+                                                    );
+                                                    ui.selectable_value(
+                                                        &mut self.settings.one_rm_formula,
+                                                        OneRmFormula::Lombardi,
+                                                        "Lombardi",
+                                                    );
+                                                    ui.selectable_value(
+                                                        &mut self.settings.one_rm_formula,
+                                                        OneRmFormula::Mayhew,
+                                                        "Mayhew",
+                                                    );
+                                                    ui.selectable_value(
+                                                        &mut self.settings.one_rm_formula,
+                                                        OneRmFormula::OConner,
+                                                        "O'Conner",
+                                                    );
+                                                    ui.selectable_value(
+                                                        &mut self.settings.one_rm_formula,
+                                                        OneRmFormula::Wathan,
+                                                        "Wathan",
                                                     );
                                                 });
                                             if prev != self.settings.one_rm_formula {
@@ -2900,7 +2930,7 @@ mod tests {
         s.show_smoothed = true;
         s.ma_window = 3;
         s.smoothing_method = SmoothingMethod::EMA;
-        s.one_rm_formula = OneRmFormula::Brzycki;
+        s.one_rm_formula = OneRmFormula::Wathan;
         s.start_date = Some(NaiveDate::from_ymd_opt(2024, 1, 1).unwrap());
         s.end_date = Some(NaiveDate::from_ymd_opt(2024, 2, 1).unwrap());
         s.x_axis = XAxis::WorkoutIndex;


### PR DESCRIPTION
## Summary
- expand OneRmFormula enum with Lander, Lombardi, Mayhew, O'Conner, and Wathan methods
- apply new formulas throughout plotting, analysis, and personal record calculations
- allow selecting any 1RM formula from Settings UI

## Testing
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_688c1985452c833285d7a3376b80af21