### PR TITLE
Add more one-rep max formulas

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -2432,6 +2432,11 @@ impl App for MyApp {
                                                 .selected_text(match self.settings.one_rm_formula {
                                                     OneRmFormula::Epley => "Epley",
                                                     OneRmFormula::Brzycki => "Brzycki",
+                                                    OneRmFormula::Lombardi => "Lombardi",
+                                                    OneRmFormula::Mayhew => "Mayhew",
+                                                    OneRmFormula::OConner => "O'Conner",
+                                                    OneRmFormula::Wathan => "Wathan",
+                                                    OneRmFormula::Lander => "Lander",
                                                 })
                                                 .show_ui(ui, |ui| {
                                                     ui.selectable_value(
@@ -2443,6 +2448,31 @@ impl App for MyApp {
                                                         &mut self.settings.one_rm_formula,
                                                         OneRmFormula::Brzycki,
                                                         "Brzycki",
+                                                    );
+                                                    ui.selectable_value(
+                                                        &mut self.settings.one_rm_formula,
+                                                        OneRmFormula::Lombardi,
+                                                        "Lombardi",
+                                                    );
+                                                    ui.selectable_value(
+                                                        &mut self.settings.one_rm_formula,
+                                                        OneRmFormula::Mayhew,
+                                                        "Mayhew",
+                                                    );
+                                                    ui.selectable_value(
+                                                        &mut self.settings.one_rm_formula,
+                                                        OneRmFormula::OConner,
+                                                        "O'Conner",
+                                                    );
+                                                    ui.selectable_value(
+                                                        &mut self.settings.one_rm_formula,
+                                                        OneRmFormula::Wathan,
+                                                        "Wathan",
+                                                    );
+                                                    ui.selectable_value(
+                                                        &mut self.settings.one_rm_formula,
+                                                        OneRmFormula::Lander,
+                                                        "Lander",
                                                     );
                                                 });
                                             if prev != self.settings.one_rm_formula {


### PR DESCRIPTION
## Summary
- support extra 1RM formulas (Lombardi, Mayhew, O'Conner, Wathan, Lander) and share an `estimate` helper
- compute estimated 1RM with the chosen formula in plots and stats
- allow selecting any formula from the settings UI
- test the 1RM estimators, including invalid input handling
- document formulas and rep limits for all available 1RM estimators
- exercise all one-rep-max formulas in aggregate stats and personal record tests, including boundary cases

## Testing
- `cargo test`


------
https://chatgpt.com/codex/tasks/task_e_688d460c56d88332a84d14ebbd97ffb3