### PR TITLE
Narrow settings panel width

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -2438,6 +2438,7 @@ impl App for MyApp {
             let prev_start = self.settings.start_date;
             let prev_end = self.settings.end_date;
             egui::Window::new("Settings")
+                .default_width(400.0)
                 .open(&mut self.show_settings)
                 .show(ctx, |ui| {
                     egui::ScrollArea::vertical().show(ui, |ui| {


### PR DESCRIPTION
## Summary
- Set a default width for the settings window so the panel isn't overly wide

## Testing
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_688e941c1dac8332894b4526c27a3c96