### PR TITLE
Add report export with HTML generation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -16,8 +16,10 @@ dependencies = [
  "env_logger",
  "image",
  "log",
+ "maud",
  "once_cell",
  "phf",
+ "plotters",
  "rfd",
  "serde",
  "serde_json",
@@ -170,7 +172,7 @@ dependencies = [
  "ndk-context",
  "ndk-sys",
  "num_enum",
- "thiserror",
+ "thiserror 1.0.69",
 ]
 
 [[package]]
@@ -746,7 +748,7 @@ dependencies = [
  "polling 3.9.0",
  "rustix 0.38.44",
  "slab",
- "thiserror",
+ "thiserror 1.0.69",
 ]
 
 [[package]]
@@ -760,7 +762,7 @@ dependencies = [
  "polling 3.9.0",
  "rustix 0.38.44",
  "slab",
- "thiserror",
+ "thiserror 1.0.69",
 ]
 
 [[package]]
@@ -998,6 +1000,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "core-text"
+version = "20.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c9d2790b5c08465d49f8dc05c8bcae9fea467855947db39b0f8145c091aaced5"
+dependencies = [
+ "core-foundation",
+ "core-graphics",
+ "foreign-types",
+ "libc",
+]
+
+[[package]]
 name = "cpufeatures"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1105,6 +1119,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "dirs"
+version = "6.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c3e8aa94d75141228480295a7d0e7feb620b1a5ad9f12bc40be62411e38cce4e"
+dependencies = [
+ "dirs-sys",
+]
+
+[[package]]
 name = "dirs-next"
 version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1115,13 +1138,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "dirs-sys"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e01a3366d27ee9890022452ee61b2b63a67e6f13f58900b651ff5665f0bb1fab"
+dependencies = [
+ "libc",
+ "option-ext",
+ "redox_users 0.5.2",
+ "windows-sys 0.60.2",
+]
+
+[[package]]
 name = "dirs-sys-next"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4ebda144c4fe02d1f7ea1a7d9641b6fc6b580adcfa024ae48797ecdeb6825b4d"
 dependencies = [
  "libc",
- "redox_users",
+ "redox_users 0.4.6",
  "winapi",
 ]
 
@@ -1177,6 +1212,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "75b325c5dbd37f80359721ad39aca5a29fb04c89279657cffdda8736d0c0b9d2"
 
 [[package]]
+name = "dwrote"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bfe1f192fcce01590bd8d839aca53ce0d11d803bf291b2a6c4ad925a8f0024be"
+dependencies = [
+ "lazy_static",
+ "libc",
+ "winapi",
+ "wio",
+]
+
+[[package]]
 name = "ecolor"
 version = "0.27.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1211,7 +1258,7 @@ dependencies = [
  "raw-window-handle 0.5.2",
  "raw-window-handle 0.6.2",
  "static_assertions",
- "thiserror",
+ "thiserror 1.0.69",
  "wasm-bindgen",
  "wasm-bindgen-futures",
  "web-sys",
@@ -1245,7 +1292,7 @@ dependencies = [
  "egui",
  "epaint",
  "log",
- "thiserror",
+ "thiserror 1.0.69",
  "type-map",
  "web-time",
  "wgpu",
@@ -1533,6 +1580,37 @@ dependencies = [
 ]
 
 [[package]]
+name = "float-ord"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8ce81f49ae8a0482e4c55ea62ebbd7e5a686af544c00b9d090bba3ff9be97b3d"
+
+[[package]]
+name = "font-kit"
+version = "0.14.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2c7e611d49285d4c4b2e1727b72cf05353558885cc5252f93707b845dfcaf3d3"
+dependencies = [
+ "bitflags 2.9.1",
+ "byteorder",
+ "core-foundation",
+ "core-graphics",
+ "core-text",
+ "dirs",
+ "dwrote",
+ "float-ord",
+ "freetype-sys",
+ "lazy_static",
+ "libc",
+ "log",
+ "pathfinder_geometry",
+ "pathfinder_simd",
+ "walkdir",
+ "winapi",
+ "yeslogic-fontconfig-sys",
+]
+
+[[package]]
 name = "foreign-types"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1566,6 +1644,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e13624c2627564efccf4934284bdd98cbaa14e79b0b5a141218e507b3a823456"
 dependencies = [
  "percent-encoding",
+]
+
+[[package]]
+name = "freetype-sys"
+version = "0.20.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0e7edc5b9669349acfda99533e9e0bcf26a51862ab43b08ee7745c55d28eb134"
+dependencies = [
+ "cc",
+ "libc",
+ "pkg-config",
 ]
 
 [[package]]
@@ -1702,6 +1791,16 @@ dependencies = [
 
 [[package]]
 name = "gif"
+version = "0.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "80792593675e051cf94a4b111980da2ba60d4a83e43e0048c5693baab3977045"
+dependencies = [
+ "color_quant",
+ "weezl",
+]
+
+[[package]]
+name = "gif"
 version = "0.13.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4ae047235e33e2829703574b54fdec96bfbad892062d97fed2f76022287de61b"
@@ -1825,7 +1924,7 @@ checksum = "6f56f6318968d03c18e1bcf4857ff88c61157e9da8e47c5f29055d60e1228884"
 dependencies = [
  "log",
  "presser",
- "thiserror",
+ "thiserror 1.0.69",
  "winapi",
  "windows 0.52.0",
 ]
@@ -1886,7 +1985,7 @@ dependencies = [
  "com",
  "libc",
  "libloading 0.8.8",
- "thiserror",
+ "thiserror 1.0.69",
  "widestring",
  "winapi",
 ]
@@ -2076,7 +2175,7 @@ dependencies = [
  "byteorder",
  "color_quant",
  "exr",
- "gif",
+ "gif 0.13.3",
  "jpeg-decoder",
  "num-traits",
  "png",
@@ -2161,7 +2260,7 @@ dependencies = [
  "combine",
  "jni-sys",
  "log",
- "thiserror",
+ "thiserror 1.0.69",
  "walkdir",
  "windows-sys 0.45.0",
 ]
@@ -2217,6 +2316,12 @@ name = "khronos_api"
 version = "3.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e2db585e1d738fc771bf08a151420d3ed193d9d895a36df7f6f8a9456b911ddc"
+
+[[package]]
+name = "lazy_static"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
 
 [[package]]
 name = "lebe"
@@ -2317,6 +2422,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "maud"
+version = "0.25.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b0bab19cef8a7fe1c18a43e881793bfc9d4ea984befec3ae5bd0415abf3ecf00"
+dependencies = [
+ "itoa",
+ "maud_macros",
+]
+
+[[package]]
+name = "maud_macros"
+version = "0.25.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0be95d66c3024ffce639216058e5bae17a83ecaf266ffc6e4d060ad447c9eed2"
+dependencies = [
+ "proc-macro-error",
+ "proc-macro2",
+ "quote",
+ "syn 1.0.109",
+]
+
+[[package]]
 name = "memchr"
 version = "2.7.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2408,7 +2535,7 @@ dependencies = [
  "rustc-hash 1.1.0",
  "spirv",
  "termcolor",
- "thiserror",
+ "thiserror 1.0.69",
  "unicode-xid",
 ]
 
@@ -2425,7 +2552,7 @@ dependencies = [
  "num_enum",
  "raw-window-handle 0.5.2",
  "raw-window-handle 0.6.2",
- "thiserror",
+ "thiserror 1.0.69",
 ]
 
 [[package]]
@@ -2678,6 +2805,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a4895175b425cb1f87721b59f0f286c2092bd4af812243672510e1ac53e2e0ad"
 
 [[package]]
+name = "option-ext"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "04744f49eae99ab78e0d5c0b603ab218f515ea8cfe5a456d7629ad883a3b6e7d"
+
+[[package]]
 name = "orbclient"
 version = "0.3.48"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2702,7 +2835,7 @@ version = "0.25.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "36820e9051aca1014ddc75770aab4d68bc1e9e632f0f5627c4086bc216fb583b"
 dependencies = [
- "ttf-parser",
+ "ttf-parser 0.25.1",
 ]
 
 [[package]]
@@ -2739,6 +2872,25 @@ name = "paste"
 version = "1.0.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "57c0d7b74b563b49d38dae00a0c37d4d6de9b432382b2892f0574ddcae73fd0a"
+
+[[package]]
+name = "pathfinder_geometry"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b7b7e7b4ea703700ce73ebf128e1450eb69c3a8329199ffbfb9b2a0418e5ad3"
+dependencies = [
+ "log",
+ "pathfinder_simd",
+]
+
+[[package]]
+name = "pathfinder_simd"
+version = "0.5.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bf9027960355bf3afff9841918474a81a5f972ac6d226d518060bba758b5ad57"
+dependencies = [
+ "rustc_version",
+]
 
 [[package]]
 name = "percent-encoding"
@@ -2818,6 +2970,52 @@ name = "pkg-config"
 version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7edddbd0b52d732b21ad9a5fab5c704c14cd949e5e9a1ec5929a24fded1b904c"
+
+[[package]]
+name = "plotters"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5aeb6f403d7a4911efb1e33402027fc44f29b5bf6def3effcc22d7bb75f2b747"
+dependencies = [
+ "chrono",
+ "font-kit",
+ "image",
+ "lazy_static",
+ "num-traits",
+ "pathfinder_geometry",
+ "plotters-backend",
+ "plotters-bitmap",
+ "plotters-svg",
+ "ttf-parser 0.20.0",
+ "wasm-bindgen",
+ "web-sys",
+]
+
+[[package]]
+name = "plotters-backend"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df42e13c12958a16b3f7f4386b9ab1f3e7933914ecea48da7139435263a4172a"
+
+[[package]]
+name = "plotters-bitmap"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72ce181e3f6bf82d6c1dc569103ca7b1bd964c60ba03d7e6cdfbb3e3eb7f7405"
+dependencies = [
+ "gif 0.12.0",
+ "image",
+ "plotters-backend",
+]
+
+[[package]]
+name = "plotters-svg"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "51bae2ac328883f7acdfea3d66a7c35751187f870bc81f94563733a154d7a670"
+dependencies = [
+ "plotters-backend",
+]
 
 [[package]]
 name = "png"
@@ -2924,6 +3122,30 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "edce586971a4dfaa28950c6f18ed55e0406c1ab88bbce2c6f6293a7aaba73d35"
 dependencies = [
  "toml_edit 0.22.27",
+]
+
+[[package]]
+name = "proc-macro-error"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "da25490ff9892aab3fcf7c36f08cfb902dd3e71ca0f9f9517bea02a73a5ce38c"
+dependencies = [
+ "proc-macro-error-attr",
+ "proc-macro2",
+ "quote",
+ "syn 1.0.109",
+ "version_check",
+]
+
+[[package]]
+name = "proc-macro-error-attr"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a1be40180e52ecc98ad80b184934baf3d0d29f979574e439af5a55274b35f869"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "version_check",
 ]
 
 [[package]]
@@ -3062,7 +3284,18 @@ checksum = "ba009ff324d1fc1b900bd1fdb31564febe58a8ccc8a6fdbb93b543d33b13ca43"
 dependencies = [
  "getrandom 0.2.16",
  "libredox",
- "thiserror",
+ "thiserror 1.0.69",
+]
+
+[[package]]
+name = "redox_users"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4e608c6638b9c18977b00b475ac1f28d14e84b27d8d42f70e0bf1e3dec127ac"
+dependencies = [
+ "getrandom 0.2.16",
+ "libredox",
+ "thiserror 2.0.12",
 ]
 
 [[package]]
@@ -3148,6 +3381,15 @@ name = "rustc-hash"
 version = "2.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "357703d41365b4b27c590e3ed91eabb1b663f07c4c084095e60cbed4362dff0d"
+
+[[package]]
+name = "rustc_version"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cfcb3a22ef46e85b45de6ee7e79d063319ebb6594faafcf1c225ea92ab6e9b92"
+dependencies = [
+ "semver",
+]
 
 [[package]]
 name = "rustix"
@@ -3271,6 +3513,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "semver"
+version = "1.0.26"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "56e6fa9c48d24d85fb3de5ad847117517440f6beceb7798af16b4a87d616b8d0"
+
+[[package]]
 name = "serde"
 version = "1.0.219"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3386,7 +3634,7 @@ dependencies = [
  "log",
  "memmap2",
  "rustix 0.38.44",
- "thiserror",
+ "thiserror 1.0.69",
  "wayland-backend",
  "wayland-client",
  "wayland-csd-frame",
@@ -3411,7 +3659,7 @@ dependencies = [
  "log",
  "memmap2",
  "rustix 0.38.44",
- "thiserror",
+ "thiserror 1.0.69",
  "wayland-backend",
  "wayland-client",
  "wayland-csd-frame",
@@ -3552,7 +3800,16 @@ version = "1.0.69"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6aaf5339b578ea85b50e080feb250a3e8ae8cfcdff9a461c9ec2904bc923f52"
 dependencies = [
- "thiserror-impl",
+ "thiserror-impl 1.0.69",
+]
+
+[[package]]
+name = "thiserror"
+version = "2.0.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "567b8a2dae586314f7be2a752ec7474332959c6460e02bde30d702a66d488708"
+dependencies = [
+ "thiserror-impl 2.0.12",
 ]
 
 [[package]]
@@ -3560,6 +3817,17 @@ name = "thiserror-impl"
 version = "1.0.69"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4fee6c4efc90059e10f81e6d42c60a18f76588c3d74cb83a0b242a2b6c7504c1"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.104",
+]
+
+[[package]]
+name = "thiserror-impl"
+version = "2.0.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f7cf42b4507d8ea322120659672cf1b9dbb93f8f2d4ecfd6e51350ff5b17a1d"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3670,6 +3938,12 @@ checksum = "b9d12581f227e93f094d3af2ae690a574abb8a2b9b7a96e7cfe9647b2b617678"
 dependencies = [
  "once_cell",
 ]
+
+[[package]]
+name = "ttf-parser"
+version = "0.20.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "17f77d76d837a7830fe1d4f12b7b4ba4192c1888001c7164257e4bc6d21d96b4"
 
 [[package]]
 name = "ttf-parser"
@@ -4134,7 +4408,7 @@ dependencies = [
  "raw-window-handle 0.6.2",
  "rustc-hash 1.1.0",
  "smallvec",
- "thiserror",
+ "thiserror 1.0.69",
  "web-sys",
  "wgpu-hal",
  "wgpu-types",
@@ -4174,7 +4448,7 @@ dependencies = [
  "renderdoc-sys",
  "rustc-hash 1.1.0",
  "smallvec",
- "thiserror",
+ "thiserror 1.0.69",
  "wasm-bindgen",
  "web-sys",
  "wgpu-types",
@@ -4695,6 +4969,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "wio"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5d129932f4644ac2396cb456385cbf9e63b5b30c6e8dc4820bdca4eb082037a5"
+dependencies = [
+ "winapi",
+]
+
+[[package]]
 name = "wit-bindgen-rt"
 version = "0.39.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4781,6 +5064,17 @@ name = "xml-rs"
 version = "0.8.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6fd8403733700263c6eb89f192880191f1b83e332f7a20371ddcf421c4a337c7"
+
+[[package]]
+name = "yeslogic-fontconfig-sys"
+version = "6.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "503a066b4c037c440169d995b869046827dbc71263f6e8f3be6d77d4f3229dbd"
+dependencies = [
+ "dlib",
+ "once_cell",
+ "pkg-config",
+]
 
 [[package]]
 name = "yoke"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,6 +21,8 @@ phf = { version = "0.11", features = ["macros"] }
 ureq = { version = "2", features = ["json"] }
 once_cell = "1"
 strsim = "0.10"
+maud = "0.25"
+plotters = "0.3"
 
 [dev-dependencies]
 tempfile = "3"

--- a/src/main.rs
+++ b/src/main.rs
@@ -34,6 +34,8 @@ use export::{
     save_entries_csv, save_entries_json, save_prs_csv, save_prs_json, save_stats_csv,
     save_stats_json,
 };
+mod report;
+use report::export_html_report;
 mod body_parts;
 use body_parts::ExerciseType;
 mod exercise_mapping;
@@ -1734,6 +1736,30 @@ impl App for MyApp {
                                         log::error!("Failed to export entries: {e}");
                                     }
                                 }
+                            }
+                        }
+                        ui.close_menu();
+                    }
+                    if ui.button("Export Report").clicked() {
+                        if let Some(path) = FileDialog::new()
+                            .add_filter("HTML", &["html"])
+                            .save_file()
+                        {
+                            let prs_map = analysis::personal_records(
+                                &self.workouts,
+                                self.settings.one_rm_formula,
+                                self.settings.start_date,
+                                self.settings.end_date,
+                            );
+                            let prs: Vec<_> = prs_map.into_iter().collect();
+                            if let Err(e) = export_html_report(
+                                &path,
+                                &self.workouts,
+                                &self.stats,
+                                &prs,
+                                self.settings.weight_unit,
+                            ) {
+                                log::error!("Failed to export report: {e}");
                             }
                         }
                         ui.close_menu();

--- a/src/report.rs
+++ b/src/report.rs
@@ -1,0 +1,200 @@
+use crate::{
+    analysis::{aggregate_weekly_summary, BasicStats, ExerciseRecord},
+    WeightUnit, WorkoutEntry,
+};
+use maud::{html, Markup};
+use plotters::prelude::*;
+use std::path::Path;
+
+trait FormatOption {
+    fn fmt_opt(self) -> String;
+}
+
+impl FormatOption for Option<f32> {
+    fn fmt_opt(self) -> String {
+        self.map(|v| format!("{:.1}", v))
+            .unwrap_or_else(|| "-".into())
+    }
+}
+
+impl FormatOption for f32 {
+    fn fmt_opt(self) -> String {
+        format!("{:.1}", self)
+    }
+}
+
+pub fn export_html_report<P: AsRef<Path>>(
+    path: P,
+    entries: &[WorkoutEntry],
+    stats: &BasicStats,
+    prs: &[(String, ExerciseRecord)],
+    unit: WeightUnit,
+) -> std::io::Result<()> {
+    let path = path.as_ref();
+    let chart_path = path.with_extension("png");
+    let chart_file = match generate_volume_chart(entries, unit, &chart_path) {
+        Ok(_) => chart_path
+            .file_name()
+            .unwrap_or_else(|| std::ffi::OsStr::new("")),
+        Err(e) => {
+            eprintln!("Failed to generate chart: {}", e);
+            std::ffi::OsStr::new("")
+        }
+    };
+    let markup = build_html(stats, prs, chart_file);
+    std::fs::write(path, markup.into_string())
+}
+
+fn generate_volume_chart(
+    entries: &[WorkoutEntry],
+    unit: WeightUnit,
+    path: &Path,
+) -> Result<(), Box<dyn std::error::Error>> {
+    let weeks = aggregate_weekly_summary(entries, None, None);
+    let root = BitMapBackend::new(path, (800, 400)).into_drawing_area();
+    root.fill(&WHITE)?;
+    if weeks.is_empty() {
+        root.present()?;
+        return Ok(());
+    }
+    let max = weeks
+        .iter()
+        .map(|w| w.total_volume * unit.factor())
+        .fold(0.0_f32, f32::max);
+    let mut chart = ChartBuilder::on(&root)
+        .caption("Weekly Volume", ("sans-serif", 25))
+        .margin(5)
+        .x_label_area_size(30)
+        .y_label_area_size(40)
+        .build_cartesian_2d(0..weeks.len(), 0f32..max)?;
+    chart
+        .configure_mesh()
+        .disable_mesh()
+        .x_desc("Week")
+        .y_desc(format!("Volume ({:?})", unit))
+        .draw()?;
+    chart.draw_series(LineSeries::new(
+        weeks
+            .iter()
+            .enumerate()
+            .map(|(i, w)| (i, w.total_volume * unit.factor())),
+        &BLUE,
+    ))?;
+    root.present()?;
+    Ok(())
+}
+
+fn build_html(
+    stats: &BasicStats,
+    prs: &[(String, ExerciseRecord)],
+    chart_file: &std::ffi::OsStr,
+) -> Markup {
+    html! {
+        html {
+            head { meta charset="utf-8"; title { "Workout Report" } }
+            body {
+                h1 { "Summary" }
+                table border="1" {
+                    tr { th { "Total Workouts" } td { (stats.total_workouts) } }
+                    tr { th { "Avg Sets/Workout" } td { (stats.avg_sets_per_workout.fmt_opt()) } }
+                    tr { th { "Avg Reps/Set" } td { (stats.avg_reps_per_set.fmt_opt()) } }
+                    tr { th { "Avg Days Between" } td { (stats.avg_days_between.fmt_opt()) } }
+                    tr { th { "Most Common Exercise" } td { (stats.most_common_exercise.clone().unwrap_or_default()) } }
+                }
+                h1 { "Personal Records" }
+                table border="1" {
+                    tr { th { "Exercise" } th { "Max Weight" } th { "Max Volume" } th { "Best Est 1RM" } }
+                    @for (ex, rec) in prs {
+                        tr {
+                            td { (ex) }
+                            td { (rec.max_weight.map(|v| format!("{:.1}", v)).unwrap_or_else(|| "-".into())) }
+                            td { (rec.max_volume.map(|v| format!("{:.1}", v)).unwrap_or_else(|| "-".into())) }
+                            td { (rec.best_est_1rm.map(|v| format!("{:.1}", v)).unwrap_or_else(|| "-".into())) }
+                        }
+                    }
+                }
+                h1 { "Weekly Volume" }
+                @if chart_file.is_empty() {
+                    p { "Chart unavailable" }
+                } @else {
+                    img src=(chart_file.to_string_lossy());
+                }
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::ffi::OsStr;
+
+    #[test]
+    fn format_option_for_option_f32() {
+        let none: Option<f32> = None;
+        assert_eq!(none.fmt_opt(), "-");
+        assert_eq!(Some(3.46_f32).fmt_opt(), "3.5");
+        assert_eq!(Some(-1.27_f32).fmt_opt(), "-1.3");
+        assert_eq!(Some(f32::INFINITY).fmt_opt(), "inf");
+        assert_eq!(Some(f32::NEG_INFINITY).fmt_opt(), "-inf");
+        assert_eq!(Some(f32::NAN).fmt_opt(), "NaN");
+    }
+
+    #[test]
+    fn format_option_for_f32() {
+        assert_eq!(3.46_f32.fmt_opt(), "3.5");
+        assert_eq!((-1.27_f32).fmt_opt(), "-1.3");
+        assert_eq!(f32::INFINITY.fmt_opt(), "inf");
+        assert_eq!(f32::NEG_INFINITY.fmt_opt(), "-inf");
+        assert_eq!(f32::NAN.fmt_opt(), "NaN");
+    }
+
+    #[test]
+    fn build_html_renders_placeholders() {
+        use crate::analysis::{BasicStats, ExerciseRecord};
+
+        let stats = BasicStats {
+            total_workouts: 10,
+            avg_sets_per_workout: 3.46,
+            avg_reps_per_set: 8.88,
+            avg_days_between: 2.0,
+            most_common_exercise: None,
+        };
+
+        let mut rec = ExerciseRecord::default();
+        rec.max_weight = Some(150.0);
+        rec.max_volume = None;
+        rec.best_est_1rm = Some(200.0);
+        let prs = vec![("Bench".to_string(), rec)];
+
+        let output = build_html(&stats, &prs, OsStr::new("chart.png")).into_string();
+
+        assert!(output.contains("3.5"));
+        assert!(output.contains("8.9"));
+        assert!(output.contains("2.0"));
+        assert!(output.contains("<td>-</td>"));
+        assert!(output.contains("150.0"));
+        assert!(output.contains("200.0"));
+    }
+
+    #[test]
+    fn build_html_handles_empty_chart_file() {
+        use crate::analysis::{BasicStats, ExerciseRecord};
+
+        let stats = BasicStats {
+            total_workouts: 0,
+            avg_sets_per_workout: 0.0,
+            avg_reps_per_set: 0.0,
+            avg_days_between: 0.0,
+            most_common_exercise: None,
+        };
+
+        let prs: Vec<(String, ExerciseRecord)> = Vec::new();
+
+        let output = build_html(&stats, &prs, OsStr::new(""));
+        let output = output.into_string();
+
+        assert!(output.contains("Chart unavailable"));
+        assert!(!output.contains("<img"));
+    }
+}


### PR DESCRIPTION
## Summary
- add `maud` and `plotters` dependencies for generating HTML reports with charts
- introduce report module to build weekly volume chart and summary/PR tables
- wire up "Export Report" option in File menu to write the HTML report
- ensure HTML report safely formats optional averages with a placeholder
- guard against missing chart filenames by rendering a fallback message instead of an empty img tag
- add unit tests verifying `FormatOption`, HTML report rendering for missing values, and empty chart file fallback
- keep report generation working even when chart creation fails, logging the error and omitting the image

## Testing
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_688eb9f165508332bb0f967afbf5d44a