### PR TITLE
Normalize exercise filtering

### DIFF
--- a/src/analysis.rs
+++ b/src/analysis.rs
@@ -1,6 +1,7 @@
 // Module for analyzing workout data
 use crate::WorkoutEntry;
 use crate::body_parts::body_part_for;
+use crate::exercise_utils::normalize_exercise;
 use crate::plotting::OneRmFormula;
 use chrono::{Datelike, NaiveDate};
 use serde::{Deserialize, Serialize};
@@ -155,8 +156,10 @@ pub fn aggregate_rep_counts(
     end: Option<NaiveDate>,
 ) -> BTreeMap<u32, usize> {
     let mut map: BTreeMap<u32, usize> = BTreeMap::new();
+    let normalized: Vec<String> = exercises.iter().map(|s| normalize_exercise(s)).collect();
     for e in entries {
-        if exercises.is_empty() || exercises.iter().any(|ex| ex == &e.exercise) {
+        let ex_name = normalize_exercise(&e.exercise);
+        if normalized.is_empty() || normalized.iter().any(|ex| ex == &ex_name) {
             if let Some(d) = parse_date(&e.date) {
                 if start.map_or(true, |s| d >= s) && end.map_or(true, |e2| d <= e2) {
                     *map.entry(e.reps).or_insert(0) += 1;
@@ -661,7 +664,7 @@ mod tests {
     #[test]
     fn test_aggregate_rep_counts() {
         let entries = sample_entries();
-        let ex = vec!["Squat".to_string(), "Bench".to_string()];
+        let ex = vec!["squat".to_string(), "BENCH".to_string()];
         let map = aggregate_rep_counts(&entries, &ex, None, None);
         assert_eq!(map.get(&5), Some(&3));
 

--- a/src/exercise_utils.rs
+++ b/src/exercise_utils.rs
@@ -1,0 +1,3 @@
+pub fn normalize_exercise(name: &str) -> String {
+    name.trim().to_lowercase()
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -38,6 +38,8 @@ mod report;
 use report::export_html_report;
 mod body_parts;
 use body_parts::ExerciseType;
+mod exercise_utils;
+use exercise_utils::normalize_exercise;
 mod exercise_mapping;
 mod sync;
 
@@ -831,11 +833,14 @@ impl MyApp {
 
     /// Return entries that match the current filters and the selected exercises.
     fn filtered_selected_entries(&self) -> Vec<WorkoutEntry> {
+        let selected: Vec<String> = self
+            .selected_exercises
+            .iter()
+            .map(|s| normalize_exercise(s))
+            .collect();
         self.filtered_entries()
             .into_iter()
-            .filter(|e| {
-                self.selected_exercises.is_empty() || self.selected_exercises.contains(&e.exercise)
-            })
+            .filter(|e| selected.is_empty() || selected.contains(&normalize_exercise(&e.exercise)))
             .collect()
     }
 
@@ -2098,10 +2103,15 @@ impl App for MyApp {
                             if let Some(path) =
                                 FileDialog::new().add_filter("CSV", &["csv"]).save_file()
                             {
+                                let sel_norm: Vec<String> = self
+                                    .selected_exercises
+                                    .iter()
+                                    .map(|s| normalize_exercise(s))
+                                    .collect();
                                 let entries: Vec<WorkoutEntry> = self
                                     .filtered_entries()
                                     .into_iter()
-                                    .filter(|e| self.selected_exercises.contains(&e.exercise))
+                                    .filter(|e| sel_norm.contains(&normalize_exercise(&e.exercise)))
                                     .collect();
                                 if let Err(e) = save_entries_csv(&path, &entries) {
                                     log::error!("Failed to export entries: {e}");


### PR DESCRIPTION
## Summary
- Normalize exercise names before comparison to avoid case-sensitive mismatches
- Apply case-insensitive filtering across analysis, plotting, and UI export paths
- Add tests ensuring case-insensitive exercise handling

## Testing
- `cargo test`


------
https://chatgpt.com/codex/tasks/task_e_688f5e880870833281ab7563ba44561a