### PR TITLE
Add regex-enabled notes query with tag-aware UI

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -20,6 +20,7 @@ dependencies = [
  "once_cell",
  "phf",
  "plotters",
+ "regex",
  "rfd",
  "serde",
  "serde_json",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,6 +23,7 @@ once_cell = "1"
 strsim = "0.10"
 maud = "0.25"
 plotters = "0.3"
+regex = "1"
 
 [dev-dependencies]
 tempfile = "3"


### PR DESCRIPTION
## Summary
- parse notes filters into tag and regex components
- apply regex-powered note matching during analysis
- extend settings UI with fields for tags and regex patterns

## Testing
- `cargo test --quiet`

 