### PR TITLE
Add ACWR calculation and dashboard warnings

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -2,7 +2,7 @@
 
 use dirs_next as dirs;
 use eframe::{App, Frame, NativeOptions, egui};
-use egui::RichText;
+use egui::{Color32, RichText};
 use egui_extras::DatePickerButton;
 use egui_plot::{Legend, Line, MarkerShape, Plot, PlotGeometry, PlotItem, PlotPoints, Points};
 use rfd::FileDialog;
@@ -1536,12 +1536,24 @@ impl MyApp {
                             ui.label("Week");
                             ui.label("Sets");
                             ui.label("Volume");
+                            ui.label("ACWR");
                             ui.end_row();
                             for w in &weeks {
                                 ui.label(w.year.to_string());
                                 ui.label(format!("{:02}", w.week));
                                 ui.label(w.total_sets.to_string());
                                 ui.label(format!("{:.1}", w.total_volume * f));
+                                if let Some(r) = w.acwr {
+                                    if w.over_threshold {
+                                        ui.label(
+                                            RichText::new(format!("{r:.2} ⚠")).color(Color32::RED),
+                                        );
+                                    } else {
+                                        ui.label(format!("{r:.2}"));
+                                    }
+                                } else {
+                                    ui.label("-");
+                                }
                                 ui.end_row();
                             }
                         });

--- a/src/plotting.rs
+++ b/src/plotting.rs
@@ -1,4 +1,5 @@
 use chrono::{Datelike, NaiveDate};
+use egui::Color32;
 use egui_plot::{Bar, BarChart, Line, PlotPoints, Points};
 
 use crate::body_parts::body_part_for;
@@ -465,7 +466,13 @@ pub fn weekly_summary_plot(weeks: &[WeeklySummary], unit: WeightUnit) -> (BarCha
     let bars: Vec<Bar> = weeks
         .iter()
         .enumerate()
-        .map(|(idx, w)| Bar::new(idx as f64, w.total_sets as f64))
+        .map(|(idx, w)| {
+            let mut bar = Bar::new(idx as f64, w.total_sets as f64);
+            if w.over_threshold {
+                bar = bar.fill(Color32::RED);
+            }
+            bar
+        })
         .collect();
     let pts: Vec<[f64; 2]> = weeks
         .iter()


### PR DESCRIPTION
## Summary
- compute acute/chronic workload ratio and flag high-risk weeks
- show ACWR in weekly summary table with warning indicators
- highlight weeks exceeding threshold in weekly bar chart

## Testing
- `cargo test`


------
https://chatgpt.com/codex/tasks/task_e_688f65dc449c8332b3e1e47af3b79418