### PR TITLE
Handle optional weight and reps in workouts

### DIFF
--- a/src/report.rs
+++ b/src/report.rs
@@ -1,9 +1,9 @@
 use crate::{
-    analysis::{aggregate_weekly_summary, BasicStats, ExerciseRecord},
     WeightUnit, WorkoutEntry,
+    analysis::{BasicStats, ExerciseRecord, aggregate_weekly_summary},
 };
 use chrono::{Datelike, Duration, NaiveDate, Weekday};
-use maud::{html, Markup};
+use maud::{Markup, html};
 use plotters::prelude::*;
 use std::path::Path;
 
@@ -94,8 +94,7 @@ fn generate_volume_chart(
 
     chart.draw_series(LineSeries::new(
         weeks.iter().map(|w| {
-            let date =
-                NaiveDate::from_isoywd_opt(w.year, w.week, Weekday::Mon).unwrap();
+            let date = NaiveDate::from_isoywd_opt(w.year, w.week, Weekday::Mon).unwrap();
             let idx = date.signed_duration_since(start).num_weeks() as i32;
             (idx, w.total_volume * unit.factor())
         }),

--- a/src/sync.rs
+++ b/src/sync.rs
@@ -32,22 +32,23 @@ pub fn fetch_latest_workouts(
                                 .get("weight")
                                 .or_else(|| set.get("weight_kg"))
                                 .or_else(|| set.get("weight_lb"))
-                                .and_then(|v| v.as_f64())
-                                .unwrap_or(0.0) as f32;
-                            let reps = set.get("reps").and_then(|v| v.as_u64()).unwrap_or(0) as u32;
-                            let mut raw = RawWorkoutRow::default();
-                            raw.start_time = start_time.to_string();
-                            raw.exercise_title = name.to_string();
-                            raw.weight_kg = Some(weight);
-                            raw.reps = Some(reps);
-                            let entry = WorkoutEntry {
-                                date: date.clone(),
-                                exercise: name.to_string(),
-                                weight: weight * 2.20462,
-                                reps,
-                                raw,
-                            };
-                            entries.push(entry);
+                                .and_then(|v| v.as_f64());
+                            let reps = set.get("reps").and_then(|v| v.as_u64());
+                            if let (Some(weight), Some(reps)) = (weight, reps) {
+                                let mut raw = RawWorkoutRow::default();
+                                raw.start_time = start_time.to_string();
+                                raw.exercise_title = name.to_string();
+                                raw.weight_kg = Some(weight as f32);
+                                raw.reps = Some(reps as u32);
+                                let entry = WorkoutEntry {
+                                    date: date.clone(),
+                                    exercise: name.to_string(),
+                                    weight: Some(weight as f32 * 2.20462),
+                                    reps: Some(reps as u32),
+                                    raw,
+                                };
+                                entries.push(entry);
+                            }
                         }
                     }
                 }


### PR DESCRIPTION
## Summary
- store optional weight and reps in `WorkoutEntry`
- skip entries lacking weight or reps during CSV parsing and analysis
- add regression test ensuring sets missing weight/reps are ignored

## Testing
- `cargo test`


------
https://chatgpt.com/codex/tasks/task_e_688f725444408332844ca962dbfcfb69