### PR TITLE
Handle unauthorized Hevy sync

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -712,6 +712,16 @@ impl MyApp {
 
                         self.toast_start = Some(Instant::now());
                     }
+                    Err(sync::SyncError::Unauthorized) => {
+                        log::error!("Sync failed: unauthorized");
+                        self.pr_message = Some(
+                            "Hevy API key unauthorized. Please update it in settings.".to_string(),
+                        );
+                        self.pr_toast_start = Some(Instant::now());
+                        self.settings.hevy_api_key = None;
+                        self.settings.save();
+                        self.show_settings = true;
+                    }
                     Err(e) => {
                         log::error!("Sync failed: {e}");
                     }


### PR DESCRIPTION
## Summary
- add `SyncError` with `Unauthorized` variant to capture 401 from Hevy API
- show toast and clear API key when sync returns unauthorized

## Testing
- `cargo test`


------
https://chatgpt.com/codex/tasks/task_e_688fb526d8f083329c505ee8cc2b470e