### PR TITLE
Add configurable grid layout for plots

### DIFF
--- a/src/plotting.rs
+++ b/src/plotting.rs
@@ -1597,7 +1597,10 @@ mod tests {
         );
         let lw = res.into_iter().next().unwrap();
         assert_eq!(lw.records.len(), 2);
-        assert_eq!(lw.records[0].date, NaiveDate::from_ymd_opt(2024, 1, 1).unwrap());
+        assert_eq!(
+            lw.records[0].date,
+            NaiveDate::from_ymd_opt(2024, 1, 1).unwrap()
+        );
         assert_eq!(lw.records[0].weight, 100.0);
         assert_eq!(lw.records[0].reps, 5);
     }


### PR DESCRIPTION
## Summary
- add persistent settings for plot grid columns and rows
- update plot drawing to size plots according to grid cells
- render comparison plots in an egui Grid for configurable layout

## Testing
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_688ff9de391c8332affcb139efbf39f9