### PR TITLE
Add menu option to reprocess workout body-part mappings

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -2144,6 +2144,18 @@ impl App for MyApp {
                         self.show_about = true;
                         ui.close_menu();
                     }
+                    if ui.button("Reprocess Workouts").clicked() {
+                        let updated = body_parts::update_mappings_from_workouts(&self.workouts);
+                        if updated > 0 {
+                            exercise_mapping::save();
+                            self.stats = compute_stats(
+                                &self.workouts,
+                                self.settings.start_date,
+                                self.settings.end_date,
+                            );
+                        }
+                        ui.close_menu();
+                    }
                     ui.menu_button("Export", |ui| {
                         if ui.button("Export Stats").clicked() {
                             if let Some(path) = FileDialog::new()


### PR DESCRIPTION
## Summary
- add helper to refresh exercise muscle mappings using built-in defaults
- add unit test for mapping refresh
- provide `Reprocess Workouts` menu action to update and save mappings

## Testing
- `cargo test`

------
 