### PR TITLE
Add full mapping import/export

### DIFF
--- a/src/exercise_mapping.rs
+++ b/src/exercise_mapping.rs
@@ -1,9 +1,13 @@
 use once_cell::sync::Lazy;
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
+use std::io;
+use std::path::Path;
 use std::sync::Mutex;
 
 use dirs_next as dirs;
+
+use crate::body_parts;
 
 #[derive(Debug, Clone, Serialize, Deserialize, Default)]
 pub struct MuscleMapping {
@@ -56,4 +60,37 @@ pub fn remove(ex: &str) {
 
 pub fn all() -> HashMap<String, MuscleMapping> {
     MAPPINGS.lock().unwrap().clone()
+}
+
+pub fn all_with_defaults() -> HashMap<String, MuscleMapping> {
+    let guard = MAPPINGS.lock().unwrap();
+    let mut map = HashMap::new();
+    for ex in body_parts::EXERCISES.keys() {
+        map.insert(
+            (*ex).to_string(),
+            guard.get(*ex).cloned().unwrap_or_default(),
+        );
+    }
+    map
+}
+
+pub fn export_all<P: AsRef<Path>>(path: P) -> io::Result<()> {
+    let map = all_with_defaults();
+    if let Some(parent) = path.as_ref().parent() {
+        std::fs::create_dir_all(parent)?;
+    }
+    let data =
+        serde_json::to_string_pretty(&map).map_err(|e| io::Error::new(io::ErrorKind::Other, e))?;
+    std::fs::write(path, data)
+}
+
+pub fn import_all<P: AsRef<Path>>(path: P) -> io::Result<()> {
+    let data = std::fs::read_to_string(path)?;
+    let mut map: HashMap<String, MuscleMapping> =
+        serde_json::from_str(&data).map_err(|e| io::Error::new(io::ErrorKind::Other, e))?;
+    for ex in body_parts::EXERCISES.keys() {
+        map.entry((*ex).to_string()).or_default();
+    }
+    *MAPPINGS.lock().unwrap() = map;
+    Ok(())
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -3714,6 +3714,28 @@ impl App for MyApp {
                             }
                         });
                     }
+                    ui.horizontal(|ui| {
+                        if ui.button("Export Mapping").clicked() {
+                            if let Some(path) =
+                                FileDialog::new().add_filter("JSON", &["json"]).save_file()
+                            {
+                                if let Err(e) = exercise_mapping::export_all(&path) {
+                                    log::error!("Failed to export mapping: {e}");
+                                }
+                            }
+                        }
+                        if ui.button("Import Mapping").clicked() {
+                            if let Some(path) =
+                                FileDialog::new().add_filter("JSON", &["json"]).pick_file()
+                            {
+                                if let Err(e) = exercise_mapping::import_all(&path) {
+                                    log::error!("Failed to import mapping: {e}");
+                                } else {
+                                    self.mapping_dirty = true;
+                                }
+                            }
+                        }
+                    });
                     if ui.button("Open Config Directory").clicked() {
                         if let Some(dir) = dirs::config_dir() {
                             let _ = open::that(dir);


### PR DESCRIPTION
## Summary
- allow exporting and importing a complete exercise mapping with defaults for unmapped exercises
- add Muscle Mapping UI controls to import or export mappings via file dialog

## Testing
- `cargo test`
 