### PR TITLE
Allow resizing muscle mapping table columns

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -3619,10 +3619,11 @@ impl App for MyApp {
                         .show(ui, |ui| {
                             egui_extras::TableBuilder::new(ui)
                                 .striped(true)
-                                .column(egui_extras::Column::auto())
-                                .column(egui_extras::Column::remainder())
-                                .column(egui_extras::Column::remainder())
-                                .column(egui_extras::Column::remainder())
+                                .resizable(true)
+                                .column(egui_extras::Column::auto().resizable(true))
+                                .column(egui_extras::Column::initial(150.0).resizable(true))
+                                .column(egui_extras::Column::initial(100.0).resizable(true))
+                                .column(egui_extras::Column::initial(150.0).resizable(true))
                                 .header(row_height, |mut header| {
                                     header.col(|ui| {
                                         ui.label("");


### PR DESCRIPTION
## Summary
- allow muscle mapping table and its columns to be resizable

## Testing
- `cargo test`


------
https://chatgpt.com/codex/tasks/task_e_6891268e9cd0833293d8f64d60626d1e