### PR TITLE
Allow merging multiple mapping files

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,3 +66,7 @@ the workout date, exercise name, weight and reps.
   the date range from the settings as well as an exercise filter.
 
 Use the drop‑down at the top of the window to change the exercise displayed in the plots. Open the **Settings** window from the **File** menu to choose whether each plot is shown and select the formula (Epley or Brzycki) used for estimating 1RM.
+
+## Exercise Mapping
+
+The dashboard keeps a JSON mapping of exercises to muscle groups. You can export the current mapping from the mapping management window. To combine mappings from different sources, click **Import Mapping** and select multiple JSON files. They will be merged in the order selected, with later files overriding earlier entries. After merging you can use **Export Mapping** to save the combined map to a single JSON file for reuse elsewhere.

--- a/src/exercise_mapping.rs
+++ b/src/exercise_mapping.rs
@@ -94,3 +94,20 @@ pub fn import_all<P: AsRef<Path>>(path: P) -> io::Result<()> {
     *MAPPINGS.lock().unwrap() = map;
     Ok(())
 }
+
+pub fn merge_files<P: AsRef<Path>>(paths: &[P]) -> io::Result<()> {
+    let mut map: HashMap<String, MuscleMapping> = HashMap::new();
+    for p in paths {
+        let data = std::fs::read_to_string(p.as_ref())?;
+        let part: HashMap<String, MuscleMapping> =
+            serde_json::from_str(&data).map_err(|e| io::Error::new(io::ErrorKind::Other, e))?;
+        for (k, v) in part {
+            map.insert(k, v);
+        }
+    }
+    for ex in body_parts::EXERCISES.keys() {
+        map.entry((*ex).to_string()).or_default();
+    }
+    *MAPPINGS.lock().unwrap() = map;
+    Ok(())
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -3731,12 +3731,18 @@ impl App for MyApp {
                             }
                         }
                         if ui.button("Import Mapping").clicked() {
-                            if let Some(path) =
-                                FileDialog::new().add_filter("JSON", &["json"]).pick_file()
+                            if let Some(paths) =
+                                FileDialog::new().add_filter("JSON", &["json"]).pick_files()
                             {
-                                if let Err(e) = exercise_mapping::import_all(&path) {
-                                    log::error!("Failed to import mapping: {e}");
+                                if let Err(e) = exercise_mapping::merge_files(&paths) {
+                                    log::error!("Failed to merge mappings: {e}");
+                                    self.pr_message =
+                                        Some(format!("Failed to merge mappings: {e}"));
+                                    self.pr_toast_start = Some(Instant::now());
                                 } else {
+                                    log::info!("Merged {} mapping files", paths.len());
+                                    self.pr_message = Some("Mappings merged".to_string());
+                                    self.pr_toast_start = Some(Instant::now());
                                     self.mapping_dirty = true;
                                 }
                             }


### PR DESCRIPTION
## Summary
- add `merge_files` helper to merge multiple exercise mapping JSON files
- support importing multiple mapping files in UI with toast feedback
- document mapping merging workflow

## Testing
- `cargo test`


------
https://chatgpt.com/codex/tasks/task_e_689130e7aa048332b03ff4848578d821