### PR TITLE
Add explicit exercise selection modes

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,6 +62,7 @@ the workout date, exercise name, weight and reps.
   * Sets per day (bar chart)
 * **Compare Window** – Open from the exercise menu to view each selected exercise in its own plot column for side‑by‑side comparison.
 * **Muscle Group Selection** – Each muscle group in the exercise menu includes **Select All** and **Deselect All** buttons for quick bulk selection.
+* **Exercise Selection** – Choose **None** from the exercise menu to hide all exercises and clear the stats.
 * **Raw Entry Table** – Open *Raw Entries* from the **File** menu to see every
   workout set in a sortable table. Columns can be sorted and the table respects
   the date range from the settings as well as an exercise filter.


### PR DESCRIPTION
## Summary
- replace `selected_exercises: Vec<String>` with an `ExerciseSelection` enum supporting `All`, `None`, or a list of exercises
- make filtering and stats respect the new `None` and `All` modes
- add a **None** choice in the exercise menu and document it in the README

## Testing
- `cargo fmt`
- `cargo test`


 