### PR TITLE
refactor: externalize exercise mappings

### DIFF
--- a/data/default_exercise_mapping.json
+++ b/data/default_exercise_mapping.json
@@ -1,0 +1,1218 @@
+{
+  "Barbell Bench Press": {
+    "primary": "Chest",
+    "secondary": [
+      "Triceps",
+      "Front Delts"
+    ],
+    "category": ""
+  },
+  "Incline DB Press": {
+    "primary": "Chest",
+    "secondary": [
+      "Triceps",
+      "Front Delts"
+    ],
+    "category": ""
+  },
+  "Flat DB Press": {
+    "primary": "Chest",
+    "secondary": [
+      "Triceps",
+      "Front Delts"
+    ],
+    "category": ""
+  },
+  "Pec Deck": {
+    "primary": "Chest",
+    "secondary": [
+      "Front Delts"
+    ],
+    "category": ""
+  },
+  "Cable Crossover": {
+    "primary": "Chest",
+    "secondary": [
+      "Front Delts"
+    ],
+    "category": ""
+  },
+  "Push-Up": {
+    "primary": "Chest",
+    "secondary": [
+      "Triceps",
+      "Core"
+    ],
+    "category": ""
+  },
+  "Machine Chest Press": {
+    "primary": "Chest",
+    "secondary": [
+      "Triceps",
+      "Front Delts"
+    ],
+    "category": ""
+  },
+  "Incline Cable Press": {
+    "primary": "Chest",
+    "secondary": [
+      "Triceps",
+      "Front Delts"
+    ],
+    "category": ""
+  },
+  "Dips (Chest Lean)": {
+    "primary": "Chest",
+    "secondary": [
+      "Triceps",
+      "Front Delts"
+    ],
+    "category": ""
+  },
+  "Overhead Barbell Press": {
+    "primary": "Shoulders",
+    "secondary": [
+      "Triceps",
+      "Upper Chest"
+    ],
+    "category": ""
+  },
+  "Dumbbell Shoulder Press": {
+    "primary": "Shoulders",
+    "secondary": [
+      "Triceps",
+      "Upper Chest"
+    ],
+    "category": ""
+  },
+  "Arnold Press": {
+    "primary": "Shoulders",
+    "secondary": [
+      "Triceps",
+      "Front Delts"
+    ],
+    "category": ""
+  },
+  "Seated Lateral Raise": {
+    "primary": "Side Delts",
+    "secondary": [
+      "Upper Traps"
+    ],
+    "category": ""
+  },
+  "Cable Lateral Raise": {
+    "primary": "Side Delts",
+    "secondary": [
+      "Upper Traps"
+    ],
+    "category": ""
+  },
+  "Dumbbell Front Raise": {
+    "primary": "Front Delts",
+    "secondary": [
+      "Upper Chest"
+    ],
+    "category": ""
+  },
+  "Rear Delt Fly (Machine or DB)": {
+    "primary": "Rear Delts",
+    "secondary": [
+      "Upper Back",
+      "Traps"
+    ],
+    "category": ""
+  },
+  "Face Pull": {
+    "primary": "Rear Delts",
+    "secondary": [
+      "Traps",
+      "Rotator Cuff"
+    ],
+    "category": ""
+  },
+  "Upright Row": {
+    "primary": "Traps",
+    "secondary": [
+      "Side Delts"
+    ],
+    "category": ""
+  },
+  "Landmine Press": {
+    "primary": "Shoulders",
+    "secondary": [
+      "Triceps",
+      "Core"
+    ],
+    "category": ""
+  },
+  "Bradford Press": {
+    "primary": "Shoulders",
+    "secondary": [
+      "Triceps",
+      "Traps"
+    ],
+    "category": ""
+  },
+  "Dumbbell Lying Rear Delt Raise": {
+    "primary": "Rear Delts",
+    "secondary": [
+      "Traps"
+    ],
+    "category": ""
+  },
+  "Cable Y-Raise": {
+    "primary": "Shoulders",
+    "secondary": [
+      "Traps",
+      "Rear Delts"
+    ],
+    "category": ""
+  },
+  "Machine Overhead Press": {
+    "primary": "Shoulders",
+    "secondary": [
+      "Triceps"
+    ],
+    "category": ""
+  },
+  "Wall Slide": {
+    "primary": "Shoulders",
+    "secondary": [
+      "Traps",
+      "Rotator Cuff"
+    ],
+    "category": ""
+  },
+  "Band Pull Apart": {
+    "primary": "Rear Delts",
+    "secondary": [
+      "Upper Back"
+    ],
+    "category": ""
+  },
+  "Cable Rear Delt Row": {
+    "primary": "Rear Delts",
+    "secondary": [
+      "Traps"
+    ],
+    "category": ""
+  },
+  "Rope Face Pull to Neck": {
+    "primary": "Rear Delts",
+    "secondary": [
+      "Traps",
+      "Rotator Cuff"
+    ],
+    "category": ""
+  },
+  "Battle Ropes": {
+    "primary": "Shoulders",
+    "secondary": [
+      "Core",
+      "Biceps"
+    ],
+    "category": ""
+  },
+  "Barbell Back Squat": {
+    "primary": "Quads",
+    "secondary": [
+      "Glutes",
+      "Hamstrings",
+      "Core"
+    ],
+    "category": ""
+  },
+  "Front Squat": {
+    "primary": "Quads",
+    "secondary": [
+      "Glutes",
+      "Core"
+    ],
+    "category": ""
+  },
+  "Goblet Squat": {
+    "primary": "Quads",
+    "secondary": [
+      "Glutes",
+      "Core"
+    ],
+    "category": ""
+  },
+  "Hack Squat": {
+    "primary": "Quads",
+    "secondary": [
+      "Glutes",
+      "Hamstrings"
+    ],
+    "category": ""
+  },
+  "Leg Press": {
+    "primary": "Quads",
+    "secondary": [
+      "Glutes",
+      "Hamstrings"
+    ],
+    "category": ""
+  },
+  "Walking Lunges": {
+    "primary": "Glutes",
+    "secondary": [
+      "Quads",
+      "Hamstrings"
+    ],
+    "category": ""
+  },
+  "Bulgarian Split Squat": {
+    "primary": "Quads",
+    "secondary": [
+      "Glutes",
+      "Core"
+    ],
+    "category": ""
+  },
+  "Step-Ups": {
+    "primary": "Glutes",
+    "secondary": [
+      "Quads",
+      "Hamstrings"
+    ],
+    "category": ""
+  },
+  "Sissy Squat": {
+    "primary": "Quads",
+    "secondary": [
+      "Core"
+    ],
+    "category": ""
+  },
+  "Reverse Lunge": {
+    "primary": "Glutes",
+    "secondary": [
+      "Quads",
+      "Hamstrings"
+    ],
+    "category": ""
+  },
+  "Curtsy Lunge": {
+    "primary": "Glutes",
+    "secondary": [
+      "Adductors",
+      "Quads"
+    ],
+    "category": ""
+  },
+  "Leg Extension": {
+    "primary": "Quads",
+    "secondary": [],
+    "category": ""
+  },
+  "Smith Machine Squat": {
+    "primary": "Quads",
+    "secondary": [
+      "Glutes",
+      "Hamstrings"
+    ],
+    "category": ""
+  },
+  "Kneeling Squat": {
+    "primary": "Glutes",
+    "secondary": [
+      "Quads"
+    ],
+    "category": ""
+  },
+  "Isometric Wall Sit": {
+    "primary": "Quads",
+    "secondary": [
+      "Glutes"
+    ],
+    "category": ""
+  },
+  "Sled Push": {
+    "primary": "Quads",
+    "secondary": [
+      "Glutes",
+      "Hamstrings",
+      "Calves"
+    ],
+    "category": ""
+  },
+  "Romanian Deadlift": {
+    "primary": "Hamstrings",
+    "secondary": [
+      "Glutes",
+      "Lower Back"
+    ],
+    "category": ""
+  },
+  "Conventional Deadlift": {
+    "primary": "Back",
+    "secondary": [
+      "Glutes",
+      "Hamstrings",
+      "Traps"
+    ],
+    "category": ""
+  },
+  "Sumo Deadlift": {
+    "primary": "Glutes",
+    "secondary": [
+      "Quads",
+      "Hamstrings",
+      "Adductors"
+    ],
+    "category": ""
+  },
+  "Trap Bar Deadlift": {
+    "primary": "Glutes",
+    "secondary": [
+      "Quads",
+      "Traps",
+      "Hamstrings"
+    ],
+    "category": ""
+  },
+  "Good Morning": {
+    "primary": "Hamstrings",
+    "secondary": [
+      "Glutes",
+      "Lower Back"
+    ],
+    "category": ""
+  },
+  "Seated Leg Curl": {
+    "primary": "Hamstrings",
+    "secondary": [
+      "Calves"
+    ],
+    "category": ""
+  },
+  "Lying Leg Curl": {
+    "primary": "Hamstrings",
+    "secondary": [
+      "Calves"
+    ],
+    "category": ""
+  },
+  "Standing Leg Curl (Cable)": {
+    "primary": "Hamstrings",
+    "secondary": [],
+    "category": ""
+  },
+  "Nordic Curl": {
+    "primary": "Hamstrings",
+    "secondary": [
+      "Glutes"
+    ],
+    "category": ""
+  },
+  "Seated Good Morning": {
+    "primary": "Hamstrings",
+    "secondary": [
+      "Glutes",
+      "Core"
+    ],
+    "category": ""
+  },
+  "Standing Calf Raise": {
+    "primary": "Calves",
+    "secondary": [],
+    "category": ""
+  },
+  "Seated Calf Raise": {
+    "primary": "Calves",
+    "secondary": [],
+    "category": ""
+  },
+  "Tibialis Raise": {
+    "primary": "Tibialis Anterior",
+    "secondary": [],
+    "category": ""
+  },
+  "Pull-Up / Chin-Up": {
+    "primary": "Lats",
+    "secondary": [
+      "Biceps",
+      "Core"
+    ],
+    "category": ""
+  },
+  "Lat Pulldown": {
+    "primary": "Lats",
+    "secondary": [
+      "Biceps",
+      "Rear Delts"
+    ],
+    "category": ""
+  },
+  "Barbell Row": {
+    "primary": "Lats",
+    "secondary": [
+      "Rear Delts",
+      "Biceps"
+    ],
+    "category": ""
+  },
+  "Dumbbell Row": {
+    "primary": "Lats",
+    "secondary": [
+      "Rear Delts",
+      "Biceps"
+    ],
+    "category": ""
+  },
+  "T-Bar Row": {
+    "primary": "Lats",
+    "secondary": [
+      "Biceps",
+      "Rear Delts"
+    ],
+    "category": ""
+  },
+  "Seated Cable Row": {
+    "primary": "Lats",
+    "secondary": [
+      "Biceps",
+      "Rear Delts"
+    ],
+    "category": ""
+  },
+  "Straight-Arm Lat Pulldown": {
+    "primary": "Lats",
+    "secondary": [
+      "Rear Delts"
+    ],
+    "category": ""
+  },
+  "Cable Pullover": {
+    "primary": "Lats",
+    "secondary": [
+      "Rear Delts"
+    ],
+    "category": ""
+  },
+  "Incline Prone Row (Chest Support)": {
+    "primary": "Lats",
+    "secondary": [
+      "Rear Delts",
+      "Biceps"
+    ],
+    "category": ""
+  },
+  "Meadows Row": {
+    "primary": "Lats",
+    "secondary": [
+      "Rear Delts",
+      "Biceps"
+    ],
+    "category": ""
+  },
+  "Incline Bench Row (DB)": {
+    "primary": "Lats",
+    "secondary": [
+      "Rear Delts",
+      "Biceps"
+    ],
+    "category": ""
+  },
+  "Kneeling Single-Arm Lat Pulldown": {
+    "primary": "Lats",
+    "secondary": [
+      "Rear Delts",
+      "Biceps"
+    ],
+    "category": ""
+  },
+  "Behind-the-Neck Pulldown": {
+    "primary": "Lats",
+    "secondary": [
+      "Rear Delts"
+    ],
+    "category": ""
+  },
+  "Inverted Row (Bodyweight)": {
+    "primary": "Lats",
+    "secondary": [
+      "Biceps",
+      "Rear Delts"
+    ],
+    "category": ""
+  },
+  "Gironda Sternum Chin-Up": {
+    "primary": "Lats",
+    "secondary": [
+      "Rear Delts",
+      "Core"
+    ],
+    "category": ""
+  },
+  "TRX Row": {
+    "primary": "Lats",
+    "secondary": [
+      "Biceps",
+      "Core"
+    ],
+    "category": ""
+  },
+  "Single-Arm DB Row": {
+    "primary": "Lats",
+    "secondary": [
+      "Biceps",
+      "Rear Delts"
+    ],
+    "category": ""
+  },
+  "Rowing Machine": {
+    "primary": "Lats",
+    "secondary": [
+      "Quads",
+      "Biceps"
+    ],
+    "category": ""
+  },
+  "Shrugs": {
+    "primary": "Traps",
+    "secondary": [],
+    "category": ""
+  },
+  "Rack Pull": {
+    "primary": "Traps",
+    "secondary": [
+      "Glutes",
+      "Hamstrings",
+      "Back"
+    ],
+    "category": ""
+  },
+  "Barbell Curl": {
+    "primary": "Biceps",
+    "secondary": [
+      "Forearms"
+    ],
+    "category": ""
+  },
+  "Dumbbell Curl": {
+    "primary": "Biceps",
+    "secondary": [
+      "Forearms"
+    ],
+    "category": ""
+  },
+  "Preacher Curl": {
+    "primary": "Biceps",
+    "secondary": [],
+    "category": ""
+  },
+  "Incline DB Curl": {
+    "primary": "Biceps",
+    "secondary": [],
+    "category": ""
+  },
+  "Cable Curl": {
+    "primary": "Biceps",
+    "secondary": [],
+    "category": ""
+  },
+  "Concentration Curl": {
+    "primary": "Biceps",
+    "secondary": [],
+    "category": ""
+  },
+  "Hammer Curl": {
+    "primary": "Biceps (Brachialis)",
+    "secondary": [
+      "Forearms"
+    ],
+    "category": ""
+  },
+  "Zottman Curl": {
+    "primary": "Biceps",
+    "secondary": [
+      "Forearms"
+    ],
+    "category": ""
+  },
+  "One-Arm Cable Curl": {
+    "primary": "Biceps",
+    "secondary": [
+      "Forearms"
+    ],
+    "category": ""
+  },
+  "Machine Bicep Curl": {
+    "primary": "Biceps",
+    "secondary": [],
+    "category": ""
+  },
+  "Drag Curl": {
+    "primary": "Biceps",
+    "secondary": [],
+    "category": ""
+  },
+  "Incline Cable Curl": {
+    "primary": "Biceps",
+    "secondary": [],
+    "category": ""
+  },
+  "Cross-Body Hammer Curl": {
+    "primary": "Biceps",
+    "secondary": [
+      "Brachialis"
+    ],
+    "category": ""
+  },
+  "Cable Rope Hammer Curl": {
+    "primary": "Biceps",
+    "secondary": [
+      "Forearms"
+    ],
+    "category": ""
+  },
+  "Cable Reverse Curl": {
+    "primary": "Forearms",
+    "secondary": [
+      "Biceps"
+    ],
+    "category": ""
+  },
+  "Wrist Roller": {
+    "primary": "Forearms",
+    "secondary": [
+      "Grip"
+    ],
+    "category": ""
+  },
+  "Spider Curl": {
+    "primary": "Biceps",
+    "secondary": [],
+    "category": ""
+  },
+  "Reverse Curl": {
+    "primary": "Forearms",
+    "secondary": [
+      "Biceps (Brachialis)"
+    ],
+    "category": ""
+  },
+  "Wrist Curl / Reverse Wrist Curl": {
+    "primary": "Forearms",
+    "secondary": [],
+    "category": ""
+  },
+  "Triceps Pushdown": {
+    "primary": "Triceps",
+    "secondary": [],
+    "category": ""
+  },
+  "Overhead Triceps Extension": {
+    "primary": "Triceps",
+    "secondary": [],
+    "category": ""
+  },
+  "Skull Crushers": {
+    "primary": "Triceps",
+    "secondary": [],
+    "category": ""
+  },
+  "Dips (Triceps Focus)": {
+    "primary": "Triceps",
+    "secondary": [
+      "Chest",
+      "Front Delts"
+    ],
+    "category": ""
+  },
+  "Close-Grip Bench Press": {
+    "primary": "Triceps",
+    "secondary": [
+      "Chest",
+      "Front Delts"
+    ],
+    "category": ""
+  },
+  "Lying Triceps Extension": {
+    "primary": "Triceps",
+    "secondary": [],
+    "category": ""
+  },
+  "Triceps Dip Machine": {
+    "primary": "Triceps",
+    "secondary": [],
+    "category": ""
+  },
+  "Crossbody Cable Triceps Extension": {
+    "primary": "Triceps",
+    "secondary": [],
+    "category": ""
+  },
+  "Triceps Rope Overhead Extension": {
+    "primary": "Triceps",
+    "secondary": [],
+    "category": ""
+  },
+  "DB Tate Press": {
+    "primary": "Triceps",
+    "secondary": [],
+    "category": ""
+  },
+  "Incline Skull Crusher": {
+    "primary": "Triceps",
+    "secondary": [],
+    "category": ""
+  },
+  "Decline Close-Grip Bench": {
+    "primary": "Triceps",
+    "secondary": [
+      "Chest",
+      "Front Delts"
+    ],
+    "category": ""
+  },
+  "Cable Triceps Kickback": {
+    "primary": "Triceps",
+    "secondary": [],
+    "category": ""
+  },
+  "V-Bar Pushdown": {
+    "primary": "Triceps",
+    "secondary": [],
+    "category": ""
+  },
+  "Kickbacks (Cable/DB)": {
+    "primary": "Triceps",
+    "secondary": [],
+    "category": ""
+  },
+  "Crunches": {
+    "primary": "Abs",
+    "secondary": [],
+    "category": ""
+  },
+  "Hanging Leg Raise": {
+    "primary": "Abs",
+    "secondary": [
+      "Hip Flexors"
+    ],
+    "category": ""
+  },
+  "Cable Crunch": {
+    "primary": "Abs",
+    "secondary": [],
+    "category": ""
+  },
+  "Reverse Crunch": {
+    "primary": "Lower Abs",
+    "secondary": [],
+    "category": ""
+  },
+  "Russian Twist": {
+    "primary": "Obliques",
+    "secondary": [
+      "Core"
+    ],
+    "category": ""
+  },
+  "Side Plank": {
+    "primary": "Obliques",
+    "secondary": [
+      "Core"
+    ],
+    "category": ""
+  },
+  "Plank": {
+    "primary": "Core",
+    "secondary": [
+      "Glutes",
+      "Abs"
+    ],
+    "category": ""
+  },
+  "Weighted Plank": {
+    "primary": "Core",
+    "secondary": [
+      "Abs",
+      "Glutes"
+    ],
+    "category": ""
+  },
+  "Cable Woodchopper": {
+    "primary": "Obliques",
+    "secondary": [
+      "Core"
+    ],
+    "category": ""
+  },
+  "Dragon Flag": {
+    "primary": "Abs",
+    "secondary": [
+      "Hip Flexors"
+    ],
+    "category": ""
+  },
+  "Hanging Knee Raise": {
+    "primary": "Abs",
+    "secondary": [
+      "Hip Flexors"
+    ],
+    "category": ""
+  },
+  "Stability Ball Crunch": {
+    "primary": "Abs",
+    "secondary": [],
+    "category": ""
+  },
+  "Weighted Decline Sit-Up": {
+    "primary": "Abs",
+    "secondary": [],
+    "category": ""
+  },
+  "Toes-to-Bar": {
+    "primary": "Abs",
+    "secondary": [
+      "Core",
+      "Lats"
+    ],
+    "category": ""
+  },
+  "Ab Wheel Rollout": {
+    "primary": "Abs",
+    "secondary": [
+      "Core",
+      "Lats"
+    ],
+    "category": ""
+  },
+  "Cable Side Bend": {
+    "primary": "Obliques",
+    "secondary": [
+      "Core"
+    ],
+    "category": ""
+  },
+  "Kneeling Cable Crunch": {
+    "primary": "Abs",
+    "secondary": [],
+    "category": ""
+  },
+  "Bear Crawl": {
+    "primary": "Core",
+    "secondary": [
+      "Shoulders",
+      "Quads"
+    ],
+    "category": ""
+  },
+  "Cable Pallof Press": {
+    "primary": "Obliques",
+    "secondary": [
+      "Core",
+      "Shoulders"
+    ],
+    "category": ""
+  },
+  "Dead Bug": {
+    "primary": "Core",
+    "secondary": [],
+    "category": ""
+  },
+  "Bird Dog": {
+    "primary": "Core",
+    "secondary": [
+      "Glutes",
+      "Lower Back"
+    ],
+    "category": ""
+  },
+  "Pallof Press": {
+    "primary": "Obliques",
+    "secondary": [
+      "Core",
+      "Shoulders"
+    ],
+    "category": ""
+  },
+  "Landmine Rotation": {
+    "primary": "Obliques",
+    "secondary": [
+      "Core",
+      "Shoulders"
+    ],
+    "category": ""
+  },
+  "Farmer's Carry": {
+    "primary": "Traps",
+    "secondary": [
+      "Core",
+      "Forearms",
+      "Grip"
+    ],
+    "category": ""
+  },
+  "Hip Thrust": {
+    "primary": "Glutes",
+    "secondary": [
+      "Hamstrings",
+      "Core"
+    ],
+    "category": ""
+  },
+  "Glute Bridge": {
+    "primary": "Glutes",
+    "secondary": [
+      "Hamstrings"
+    ],
+    "category": ""
+  },
+  "Glute Kickback (Cable)": {
+    "primary": "Glutes",
+    "secondary": [
+      "Hamstrings"
+    ],
+    "category": ""
+  },
+  "Cable Abduction": {
+    "primary": "Glute Medius",
+    "secondary": [],
+    "category": ""
+  },
+  "Adductor Machine": {
+    "primary": "Adductors",
+    "secondary": [],
+    "category": ""
+  },
+  "Abductor Machine": {
+    "primary": "Glute Medius",
+    "secondary": [],
+    "category": ""
+  },
+  "Donkey Kick": {
+    "primary": "Glutes",
+    "secondary": [
+      "Hamstrings"
+    ],
+    "category": ""
+  },
+  "Cable Kickback": {
+    "primary": "Glutes",
+    "secondary": [
+      "Hamstrings"
+    ],
+    "category": ""
+  },
+  "Machine Glute Kickback": {
+    "primary": "Glutes",
+    "secondary": [
+      "Hamstrings"
+    ],
+    "category": ""
+  },
+  "Standing Abduction (Band)": {
+    "primary": "Glute Medius",
+    "secondary": [],
+    "category": ""
+  },
+  "Standing Adduction (Cable)": {
+    "primary": "Adductors",
+    "secondary": [],
+    "category": ""
+  },
+  "Single-Leg Glute Bridge": {
+    "primary": "Glutes",
+    "secondary": [
+      "Hamstrings",
+      "Core"
+    ],
+    "category": ""
+  },
+  "Fire Hydrant (Band or BW)": {
+    "primary": "Glute Medius",
+    "secondary": [
+      "Core"
+    ],
+    "category": ""
+  },
+  "Sled Drag": {
+    "primary": "Full Body",
+    "secondary": [
+      "Glutes",
+      "Quads",
+      "Hamstrings"
+    ],
+    "category": ""
+  },
+  "Sled Row": {
+    "primary": "Back",
+    "secondary": [
+      "Biceps",
+      "Core"
+    ],
+    "category": ""
+  },
+  "Stepmill": {
+    "primary": "Glutes",
+    "secondary": [
+      "Quads",
+      "Calves"
+    ],
+    "category": ""
+  },
+  "VersaClimber": {
+    "primary": "Full Body",
+    "secondary": [
+      "Core",
+      "Shoulders",
+      "Legs"
+    ],
+    "category": ""
+  },
+  "Speed Skater (BW Plyo)": {
+    "primary": "Glutes",
+    "secondary": [
+      "Quads",
+      "Adductors"
+    ],
+    "category": ""
+  },
+  "Broad Jump": {
+    "primary": "Glutes",
+    "secondary": [
+      "Quads",
+      "Calves"
+    ],
+    "category": ""
+  },
+  "Power Clean": {
+    "primary": "Full Body",
+    "secondary": [
+      "Traps",
+      "Glutes",
+      "Quads",
+      "Core"
+    ],
+    "category": ""
+  },
+  "Clean and Jerk": {
+    "primary": "Full Body",
+    "secondary": [
+      "Triceps",
+      "Quads",
+      "Glutes"
+    ],
+    "category": ""
+  },
+  "Snatch": {
+    "primary": "Full Body",
+    "secondary": [
+      "Traps",
+      "Glutes",
+      "Core",
+      "Shoulders"
+    ],
+    "category": ""
+  },
+  "Assault Bike": {
+    "primary": "Quads",
+    "secondary": [
+      "Glutes",
+      "Hamstrings"
+    ],
+    "category": ""
+  },
+  "Neck Flexion (Harness)": {
+    "primary": "Neck",
+    "secondary": [],
+    "category": ""
+  },
+  "Neck Extension (Harness)": {
+    "primary": "Neck",
+    "secondary": [],
+    "category": ""
+  },
+  "Neck Curl (Weighted)": {
+    "primary": "Neck",
+    "secondary": [],
+    "category": ""
+  },
+  "Neck Extension (Plate)": {
+    "primary": "Neck",
+    "secondary": [],
+    "category": ""
+  },
+  "Band External Rotation": {
+    "primary": "Rotator Cuff",
+    "secondary": [],
+    "category": ""
+  },
+  "Cable L-Fly": {
+    "primary": "Rotator Cuff",
+    "secondary": [],
+    "category": ""
+  },
+  "Cuban Rotation": {
+    "primary": "Rotator Cuff",
+    "secondary": [
+      "Rear Delts"
+    ],
+    "category": ""
+  },
+  "Cable Internal Rotation": {
+    "primary": "Rotator Cuff",
+    "secondary": [],
+    "category": ""
+  },
+  "Cuban Press": {
+    "primary": "Rotator Cuff",
+    "secondary": [
+      "Shoulders",
+      "Traps"
+    ],
+    "category": ""
+  },
+  "External Rotation (Cable)": {
+    "primary": "Rotator Cuff",
+    "secondary": [],
+    "category": ""
+  },
+  "Scapular Push-Up": {
+    "primary": "Serratus Anterior",
+    "secondary": [
+      "Chest",
+      "Shoulders"
+    ],
+    "category": ""
+  },
+  "Bench": {
+    "primary": "Chest",
+    "secondary": [],
+    "category": ""
+  },
+  "Bench Press": {
+    "primary": "Chest",
+    "secondary": [],
+    "category": ""
+  },
+  "Squat": {
+    "primary": "Quads",
+    "secondary": [],
+    "category": ""
+  },
+  "Deadlift": {
+    "primary": "Back",
+    "secondary": [],
+    "category": ""
+  },
+  "Lying Leg Curl (Machine)": {
+    "primary": "Hamstrings",
+    "secondary": [
+      "Calves"
+    ],
+    "category": ""
+  },
+  "Bicep Curl": {
+    "primary": "Biceps",
+    "secondary": [
+      "Forearms"
+    ],
+    "category": ""
+  }
+}

--- a/src/analysis.rs
+++ b/src/analysis.rs
@@ -1,6 +1,7 @@
 // Module for analyzing workout data
 use crate::WorkoutEntry;
 use crate::body_parts::body_part_for;
+use crate::exercise_mapping;
 use crate::exercise_utils::normalize_exercise;
 use crate::plotting::OneRmFormula;
 use chrono::{Datelike, NaiveDate};
@@ -738,6 +739,7 @@ mod tests {
 
     #[test]
     fn test_aggregate_sets_by_body_part() {
+        exercise_mapping::load();
         let entries = sample_entries();
         let map = aggregate_sets_by_body_part(&entries, None, None);
         assert_eq!(map.get("Quads"), Some(&2));
@@ -747,6 +749,7 @@ mod tests {
 
     #[test]
     fn test_aggregate_sets_by_body_part_range() {
+        exercise_mapping::load();
         let entries = sample_entries();
         let start = NaiveDate::parse_from_str("2024-01-03", "%Y-%m-%d").ok();
         let map = aggregate_sets_by_body_part(&entries, start, None);

--- a/src/body_parts.rs
+++ b/src/body_parts.rs
@@ -1,8 +1,8 @@
 use phf::phf_map;
 use serde::{Deserialize, Serialize};
-use std::collections::{BTreeSet, HashSet};
+use std::collections::BTreeSet;
 
-use crate::{WorkoutEntry, exercise_mapping};
+use crate::exercise_mapping;
 
 /// Type of exercise based on muscle engagement.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
@@ -56,203 +56,40 @@ pub const ALL_EQUIPMENT: [Equipment; 6] = [
     Equipment::Other,
 ];
 
-/// Metadata about an exercise including its primary and secondary muscles.
+/// Metadata about an exercise excluding muscle mappings.
 #[derive(Debug, Clone, Copy)]
 pub struct ExerciseInfo {
-    pub primary: &'static str,
-    pub secondary: &'static [&'static str],
     pub kind: ExerciseType,
     pub difficulty: Option<Difficulty>,
     pub equipment: Option<Equipment>,
 }
 
 pub static EXERCISES: phf::Map<&'static str, ExerciseInfo> = phf_map! {
-    // Chest
-    "Barbell Bench Press" => ExerciseInfo { primary: "Chest", secondary: &["Triceps", "Front Delts"], kind: ExerciseType::Compound, difficulty: Some(Difficulty::Intermediate), equipment: Some(Equipment::Barbell) },
-    "Incline DB Press" => ExerciseInfo { primary: "Chest", secondary: &["Triceps", "Front Delts"], kind: ExerciseType::Compound, difficulty: None, equipment: None },
-    "Flat DB Press" => ExerciseInfo { primary: "Chest", secondary: &["Triceps", "Front Delts"], kind: ExerciseType::Compound, difficulty: None, equipment: None },
-    "Pec Deck" => ExerciseInfo { primary: "Chest", secondary: &["Front Delts"], kind: ExerciseType::Isolation, difficulty: None, equipment: None },
-    "Cable Crossover" => ExerciseInfo { primary: "Chest", secondary: &["Front Delts"], kind: ExerciseType::Isolation, difficulty: None, equipment: None },
-    "Push-Up" => ExerciseInfo { primary: "Chest", secondary: &["Triceps", "Core"], kind: ExerciseType::Compound, difficulty: Some(Difficulty::Beginner), equipment: Some(Equipment::Bodyweight) },
-    "Machine Chest Press" => ExerciseInfo { primary: "Chest", secondary: &["Triceps", "Front Delts"], kind: ExerciseType::Compound, difficulty: Some(Difficulty::Beginner), equipment: Some(Equipment::Machine) },
-    "Incline Cable Press" => ExerciseInfo { primary: "Chest", secondary: &["Triceps", "Front Delts"], kind: ExerciseType::Compound, difficulty: None, equipment: None },
-    "Dips (Chest Lean)" => ExerciseInfo { primary: "Chest", secondary: &["Triceps", "Front Delts"], kind: ExerciseType::Compound, difficulty: None, equipment: None },
-    // Shoulders
-    "Overhead Barbell Press" => ExerciseInfo { primary: "Shoulders", secondary: &["Triceps", "Upper Chest"], kind: ExerciseType::Compound, difficulty: None, equipment: None },
-    "Dumbbell Shoulder Press" => ExerciseInfo { primary: "Shoulders", secondary: &["Triceps", "Upper Chest"], kind: ExerciseType::Compound, difficulty: None, equipment: None },
-    "Arnold Press" => ExerciseInfo { primary: "Shoulders", secondary: &["Triceps", "Front Delts"], kind: ExerciseType::Compound, difficulty: None, equipment: None },
-    "Seated Lateral Raise" => ExerciseInfo { primary: "Side Delts", secondary: &["Upper Traps"], kind: ExerciseType::Isolation, difficulty: None, equipment: None },
-    "Cable Lateral Raise" => ExerciseInfo { primary: "Side Delts", secondary: &["Upper Traps"], kind: ExerciseType::Isolation, difficulty: None, equipment: None },
-    "Dumbbell Front Raise" => ExerciseInfo { primary: "Front Delts", secondary: &["Upper Chest"], kind: ExerciseType::Isolation, difficulty: None, equipment: None },
-    "Rear Delt Fly (Machine or DB)" => ExerciseInfo { primary: "Rear Delts", secondary: &["Upper Back", "Traps"], kind: ExerciseType::Isolation, difficulty: None, equipment: None },
-    "Face Pull" => ExerciseInfo { primary: "Rear Delts", secondary: &["Traps", "Rotator Cuff"], kind: ExerciseType::Isolation, difficulty: None, equipment: None },
-    "Upright Row" => ExerciseInfo { primary: "Traps", secondary: &["Side Delts"], kind: ExerciseType::Compound, difficulty: None, equipment: None },
-    "Landmine Press" => ExerciseInfo { primary: "Shoulders", secondary: &["Triceps", "Core"], kind: ExerciseType::Compound, difficulty: None, equipment: None },
-    "Bradford Press" => ExerciseInfo { primary: "Shoulders", secondary: &["Triceps", "Traps"], kind: ExerciseType::Compound, difficulty: None, equipment: None },
-    "Dumbbell Lying Rear Delt Raise" => ExerciseInfo { primary: "Rear Delts", secondary: &["Traps"], kind: ExerciseType::Isolation, difficulty: None, equipment: None },
-    "Cable Y-Raise" => ExerciseInfo { primary: "Shoulders", secondary: &["Traps", "Rear Delts"], kind: ExerciseType::Isolation, difficulty: None, equipment: None },
-    "Machine Overhead Press" => ExerciseInfo { primary: "Shoulders", secondary: &["Triceps"], kind: ExerciseType::Compound, difficulty: None, equipment: None },
-    "Wall Slide" => ExerciseInfo { primary: "Shoulders", secondary: &["Traps", "Rotator Cuff"], kind: ExerciseType::Isolation, difficulty: None, equipment: None },
-    "Band Pull Apart" => ExerciseInfo { primary: "Rear Delts", secondary: &["Upper Back"], kind: ExerciseType::Isolation, difficulty: None, equipment: None },
-    "Cable Rear Delt Row" => ExerciseInfo { primary: "Rear Delts", secondary: &["Traps"], kind: ExerciseType::Isolation, difficulty: None, equipment: None },
-    "Rope Face Pull to Neck" => ExerciseInfo { primary: "Rear Delts", secondary: &["Traps", "Rotator Cuff"], kind: ExerciseType::Isolation, difficulty: None, equipment: None },
-    "Battle Ropes" => ExerciseInfo { primary: "Shoulders", secondary: &["Core", "Biceps"], kind: ExerciseType::Compound, difficulty: None, equipment: None },
-    // Legs - Quads dominant
-    "Barbell Back Squat" => ExerciseInfo { primary: "Quads", secondary: &["Glutes", "Hamstrings", "Core"], kind: ExerciseType::Compound, difficulty: None, equipment: None },
-    "Front Squat" => ExerciseInfo { primary: "Quads", secondary: &["Glutes", "Core"], kind: ExerciseType::Compound, difficulty: None, equipment: None },
-    "Goblet Squat" => ExerciseInfo { primary: "Quads", secondary: &["Glutes", "Core"], kind: ExerciseType::Compound, difficulty: None, equipment: None },
-    "Hack Squat" => ExerciseInfo { primary: "Quads", secondary: &["Glutes", "Hamstrings"], kind: ExerciseType::Compound, difficulty: None, equipment: None },
-    "Leg Press" => ExerciseInfo { primary: "Quads", secondary: &["Glutes", "Hamstrings"], kind: ExerciseType::Compound, difficulty: None, equipment: None },
-    "Walking Lunges" => ExerciseInfo { primary: "Glutes", secondary: &["Quads", "Hamstrings"], kind: ExerciseType::Compound, difficulty: None, equipment: None },
-    "Bulgarian Split Squat" => ExerciseInfo { primary: "Quads", secondary: &["Glutes", "Core"], kind: ExerciseType::Compound, difficulty: None, equipment: None },
-    "Step-Ups" => ExerciseInfo { primary: "Glutes", secondary: &["Quads", "Hamstrings"], kind: ExerciseType::Compound, difficulty: None, equipment: None },
-    "Sissy Squat" => ExerciseInfo { primary: "Quads", secondary: &["Core"], kind: ExerciseType::Isolation, difficulty: None, equipment: None },
-    "Reverse Lunge" => ExerciseInfo { primary: "Glutes", secondary: &["Quads", "Hamstrings"], kind: ExerciseType::Compound, difficulty: None, equipment: None },
-    "Curtsy Lunge" => ExerciseInfo { primary: "Glutes", secondary: &["Adductors", "Quads"], kind: ExerciseType::Compound, difficulty: None, equipment: None },
-    "Leg Extension" => ExerciseInfo { primary: "Quads", secondary: &[], kind: ExerciseType::Isolation, difficulty: None, equipment: None },
-    "Smith Machine Squat" => ExerciseInfo { primary: "Quads", secondary: &["Glutes", "Hamstrings"], kind: ExerciseType::Compound, difficulty: None, equipment: None },
-    "Kneeling Squat" => ExerciseInfo { primary: "Glutes", secondary: &["Quads"], kind: ExerciseType::Compound, difficulty: None, equipment: None },
-    "Isometric Wall Sit" => ExerciseInfo { primary: "Quads", secondary: &["Glutes"], kind: ExerciseType::Isometric, difficulty: None, equipment: None },
-    "Sled Push" => ExerciseInfo { primary: "Quads", secondary: &["Glutes", "Hamstrings", "Calves"], kind: ExerciseType::Compound, difficulty: None, equipment: None },
-    // Posterior chain
-    "Romanian Deadlift" => ExerciseInfo { primary: "Hamstrings", secondary: &["Glutes", "Lower Back"], kind: ExerciseType::Compound, difficulty: None, equipment: None },
-    "Conventional Deadlift" => ExerciseInfo { primary: "Back", secondary: &["Glutes", "Hamstrings", "Traps"], kind: ExerciseType::Compound, difficulty: None, equipment: None },
-    "Sumo Deadlift" => ExerciseInfo { primary: "Glutes", secondary: &["Quads", "Hamstrings", "Adductors"], kind: ExerciseType::Compound, difficulty: None, equipment: None },
-    "Trap Bar Deadlift" => ExerciseInfo { primary: "Glutes", secondary: &["Quads", "Traps", "Hamstrings"], kind: ExerciseType::Compound, difficulty: None, equipment: None },
-    "Good Morning" => ExerciseInfo { primary: "Hamstrings", secondary: &["Glutes", "Lower Back"], kind: ExerciseType::Compound, difficulty: None, equipment: None },
-    "Seated Leg Curl" => ExerciseInfo { primary: "Hamstrings", secondary: &["Calves"], kind: ExerciseType::Isolation, difficulty: None, equipment: None },
-    "Lying Leg Curl" => ExerciseInfo { primary: "Hamstrings", secondary: &["Calves"], kind: ExerciseType::Isolation, difficulty: None, equipment: None },
-    "Standing Leg Curl (Cable)" => ExerciseInfo { primary: "Hamstrings", secondary: &[], kind: ExerciseType::Isolation, difficulty: None, equipment: None },
-    "Nordic Curl" => ExerciseInfo { primary: "Hamstrings", secondary: &["Glutes"], kind: ExerciseType::Isolation, difficulty: None, equipment: None },
-    "Seated Good Morning" => ExerciseInfo { primary: "Hamstrings", secondary: &["Glutes", "Core"], kind: ExerciseType::Compound, difficulty: None, equipment: None },
-    // Calves & Tibialis
-    "Standing Calf Raise" => ExerciseInfo { primary: "Calves", secondary: &[], kind: ExerciseType::Isolation, difficulty: None, equipment: None },
-    "Seated Calf Raise" => ExerciseInfo { primary: "Calves", secondary: &[], kind: ExerciseType::Isolation, difficulty: None, equipment: None },
-    "Tibialis Raise" => ExerciseInfo { primary: "Tibialis Anterior", secondary: &[], kind: ExerciseType::Isolation, difficulty: None, equipment: None },
-    // Back
-    "Pull-Up / Chin-Up" => ExerciseInfo { primary: "Lats", secondary: &["Biceps", "Core"], kind: ExerciseType::Compound, difficulty: None, equipment: None },
-    "Lat Pulldown" => ExerciseInfo { primary: "Lats", secondary: &["Biceps", "Rear Delts"], kind: ExerciseType::Compound, difficulty: None, equipment: None },
-    "Barbell Row" => ExerciseInfo { primary: "Lats", secondary: &["Rear Delts", "Biceps"], kind: ExerciseType::Compound, difficulty: None, equipment: None },
-    "Dumbbell Row" => ExerciseInfo { primary: "Lats", secondary: &["Rear Delts", "Biceps"], kind: ExerciseType::Compound, difficulty: None, equipment: None },
-    "T-Bar Row" => ExerciseInfo { primary: "Lats", secondary: &["Biceps", "Rear Delts"], kind: ExerciseType::Compound, difficulty: None, equipment: None },
-    "Seated Cable Row" => ExerciseInfo { primary: "Lats", secondary: &["Biceps", "Rear Delts"], kind: ExerciseType::Compound, difficulty: None, equipment: None },
-    "Straight-Arm Lat Pulldown" => ExerciseInfo { primary: "Lats", secondary: &["Rear Delts"], kind: ExerciseType::Isolation, difficulty: None, equipment: None },
-    "Cable Pullover" => ExerciseInfo { primary: "Lats", secondary: &["Rear Delts"], kind: ExerciseType::Isolation, difficulty: None, equipment: None },
-    "Incline Prone Row (Chest Support)" => ExerciseInfo { primary: "Lats", secondary: &["Rear Delts", "Biceps"], kind: ExerciseType::Compound, difficulty: None, equipment: None },
-    "Meadows Row" => ExerciseInfo { primary: "Lats", secondary: &["Rear Delts", "Biceps"], kind: ExerciseType::Compound, difficulty: None, equipment: None },
-    "Incline Bench Row (DB)" => ExerciseInfo { primary: "Lats", secondary: &["Rear Delts", "Biceps"], kind: ExerciseType::Compound, difficulty: None, equipment: None },
-    "Kneeling Single-Arm Lat Pulldown" => ExerciseInfo { primary: "Lats", secondary: &["Rear Delts", "Biceps"], kind: ExerciseType::Compound, difficulty: None, equipment: None },
-    "Behind-the-Neck Pulldown" => ExerciseInfo { primary: "Lats", secondary: &["Rear Delts"], kind: ExerciseType::Compound, difficulty: None, equipment: None },
-    "Inverted Row (Bodyweight)" => ExerciseInfo { primary: "Lats", secondary: &["Biceps", "Rear Delts"], kind: ExerciseType::Compound, difficulty: None, equipment: None },
-    "Gironda Sternum Chin-Up" => ExerciseInfo { primary: "Lats", secondary: &["Rear Delts", "Core"], kind: ExerciseType::Compound, difficulty: None, equipment: None },
-    "TRX Row" => ExerciseInfo { primary: "Lats", secondary: &["Biceps", "Core"], kind: ExerciseType::Compound, difficulty: None, equipment: None },
-    "Single-Arm DB Row" => ExerciseInfo { primary: "Lats", secondary: &["Biceps", "Rear Delts"], kind: ExerciseType::Compound, difficulty: None, equipment: None },
-    "Rowing Machine" => ExerciseInfo { primary: "Lats", secondary: &["Quads", "Biceps"], kind: ExerciseType::Compound, difficulty: None, equipment: None },
-    "Shrugs" => ExerciseInfo { primary: "Traps", secondary: &[], kind: ExerciseType::Isolation, difficulty: None, equipment: None },
-    "Rack Pull" => ExerciseInfo { primary: "Traps", secondary: &["Glutes", "Hamstrings", "Back"], kind: ExerciseType::Compound, difficulty: None, equipment: None },
-    // Arms - Biceps
-    "Barbell Curl" => ExerciseInfo { primary: "Biceps", secondary: &["Forearms"], kind: ExerciseType::Isolation, difficulty: None, equipment: None },
-    "Dumbbell Curl" => ExerciseInfo { primary: "Biceps", secondary: &["Forearms"], kind: ExerciseType::Isolation, difficulty: None, equipment: None },
-    "Preacher Curl" => ExerciseInfo { primary: "Biceps", secondary: &[], kind: ExerciseType::Isolation, difficulty: None, equipment: None },
-    "Incline DB Curl" => ExerciseInfo { primary: "Biceps", secondary: &[], kind: ExerciseType::Isolation, difficulty: None, equipment: None },
-    "Cable Curl" => ExerciseInfo { primary: "Biceps", secondary: &[], kind: ExerciseType::Isolation, difficulty: None, equipment: None },
-    "Concentration Curl" => ExerciseInfo { primary: "Biceps", secondary: &[], kind: ExerciseType::Isolation, difficulty: None, equipment: None },
-    "Hammer Curl" => ExerciseInfo { primary: "Biceps (Brachialis)", secondary: &["Forearms"], kind: ExerciseType::Isolation, difficulty: None, equipment: None },
-    "Zottman Curl" => ExerciseInfo { primary: "Biceps", secondary: &["Forearms"], kind: ExerciseType::Isolation, difficulty: None, equipment: None },
-    "One-Arm Cable Curl" => ExerciseInfo { primary: "Biceps", secondary: &["Forearms"], kind: ExerciseType::Isolation, difficulty: None, equipment: None },
-    "Machine Bicep Curl" => ExerciseInfo { primary: "Biceps", secondary: &[], kind: ExerciseType::Isolation, difficulty: None, equipment: None },
-    "Drag Curl" => ExerciseInfo { primary: "Biceps", secondary: &[], kind: ExerciseType::Isolation, difficulty: None, equipment: None },
-    "Incline Cable Curl" => ExerciseInfo { primary: "Biceps", secondary: &[], kind: ExerciseType::Isolation, difficulty: None, equipment: None },
-    "Cross-Body Hammer Curl" => ExerciseInfo { primary: "Biceps", secondary: &["Brachialis"], kind: ExerciseType::Isolation, difficulty: None, equipment: None },
-    "Cable Rope Hammer Curl" => ExerciseInfo { primary: "Biceps", secondary: &["Forearms"], kind: ExerciseType::Isolation, difficulty: None, equipment: None },
-    "Cable Reverse Curl" => ExerciseInfo { primary: "Forearms", secondary: &["Biceps"], kind: ExerciseType::Isolation, difficulty: None, equipment: None },
-    "Wrist Roller" => ExerciseInfo { primary: "Forearms", secondary: &["Grip"], kind: ExerciseType::Isolation, difficulty: None, equipment: None },
-    "Spider Curl" => ExerciseInfo { primary: "Biceps", secondary: &[], kind: ExerciseType::Isolation, difficulty: None, equipment: None },
-    "Reverse Curl" => ExerciseInfo { primary: "Forearms", secondary: &["Biceps (Brachialis)"], kind: ExerciseType::Isolation, difficulty: None, equipment: None },
-    "Wrist Curl / Reverse Wrist Curl" => ExerciseInfo { primary: "Forearms", secondary: &[], kind: ExerciseType::Isolation, difficulty: None, equipment: None },
-    // Arms - Triceps
-    "Triceps Pushdown" => ExerciseInfo { primary: "Triceps", secondary: &[], kind: ExerciseType::Isolation, difficulty: None, equipment: None },
-    "Overhead Triceps Extension" => ExerciseInfo { primary: "Triceps", secondary: &[], kind: ExerciseType::Isolation, difficulty: None, equipment: None },
-    "Skull Crushers" => ExerciseInfo { primary: "Triceps", secondary: &[], kind: ExerciseType::Isolation, difficulty: None, equipment: None },
-    "Dips (Triceps Focus)" => ExerciseInfo { primary: "Triceps", secondary: &["Chest", "Front Delts"], kind: ExerciseType::Compound, difficulty: None, equipment: None },
-    "Close-Grip Bench Press" => ExerciseInfo { primary: "Triceps", secondary: &["Chest", "Front Delts"], kind: ExerciseType::Compound, difficulty: None, equipment: None },
-    "Lying Triceps Extension" => ExerciseInfo { primary: "Triceps", secondary: &[], kind: ExerciseType::Isolation, difficulty: None, equipment: None },
-    "Triceps Dip Machine" => ExerciseInfo { primary: "Triceps", secondary: &[], kind: ExerciseType::Isolation, difficulty: None, equipment: None },
-    "Crossbody Cable Triceps Extension" => ExerciseInfo { primary: "Triceps", secondary: &[], kind: ExerciseType::Isolation, difficulty: None, equipment: None },
-    "Triceps Rope Overhead Extension" => ExerciseInfo { primary: "Triceps", secondary: &[], kind: ExerciseType::Isolation, difficulty: None, equipment: None },
-    "DB Tate Press" => ExerciseInfo { primary: "Triceps", secondary: &[], kind: ExerciseType::Isolation, difficulty: None, equipment: None },
-    "Incline Skull Crusher" => ExerciseInfo { primary: "Triceps", secondary: &[], kind: ExerciseType::Isolation, difficulty: None, equipment: None },
-    "Decline Close-Grip Bench" => ExerciseInfo { primary: "Triceps", secondary: &["Chest", "Front Delts"], kind: ExerciseType::Compound, difficulty: None, equipment: None },
-    "Cable Triceps Kickback" => ExerciseInfo { primary: "Triceps", secondary: &[], kind: ExerciseType::Isolation, difficulty: None, equipment: None },
-    "V-Bar Pushdown" => ExerciseInfo { primary: "Triceps", secondary: &[], kind: ExerciseType::Isolation, difficulty: None, equipment: None },
-    "Kickbacks (Cable/DB)" => ExerciseInfo { primary: "Triceps", secondary: &[], kind: ExerciseType::Isolation, difficulty: None, equipment: None },
-    // Core
-    "Crunches" => ExerciseInfo { primary: "Abs", secondary: &[], kind: ExerciseType::Isolation, difficulty: None, equipment: None },
-    "Hanging Leg Raise" => ExerciseInfo { primary: "Abs", secondary: &["Hip Flexors"], kind: ExerciseType::Isolation, difficulty: None, equipment: None },
-    "Cable Crunch" => ExerciseInfo { primary: "Abs", secondary: &[], kind: ExerciseType::Isolation, difficulty: None, equipment: None },
-    "Reverse Crunch" => ExerciseInfo { primary: "Lower Abs", secondary: &[], kind: ExerciseType::Isolation, difficulty: None, equipment: None },
-    "Russian Twist" => ExerciseInfo { primary: "Obliques", secondary: &["Core"], kind: ExerciseType::Isolation, difficulty: None, equipment: None },
-    "Side Plank" => ExerciseInfo { primary: "Obliques", secondary: &["Core"], kind: ExerciseType::Isolation, difficulty: None, equipment: None },
-    "Plank" => ExerciseInfo { primary: "Core", secondary: &["Glutes", "Abs"], kind: ExerciseType::Isometric, difficulty: None, equipment: None },
-    "Weighted Plank" => ExerciseInfo { primary: "Core", secondary: &["Abs", "Glutes"], kind: ExerciseType::Isometric, difficulty: None, equipment: None },
-    "Cable Woodchopper" => ExerciseInfo { primary: "Obliques", secondary: &["Core"], kind: ExerciseType::Isolation, difficulty: None, equipment: None },
-    "Dragon Flag" => ExerciseInfo { primary: "Abs", secondary: &["Hip Flexors"], kind: ExerciseType::Isolation, difficulty: None, equipment: None },
-    "Hanging Knee Raise" => ExerciseInfo { primary: "Abs", secondary: &["Hip Flexors"], kind: ExerciseType::Isolation, difficulty: None, equipment: None },
-    "Stability Ball Crunch" => ExerciseInfo { primary: "Abs", secondary: &[], kind: ExerciseType::Isolation, difficulty: None, equipment: None },
-    "Weighted Decline Sit-Up" => ExerciseInfo { primary: "Abs", secondary: &[], kind: ExerciseType::Isolation, difficulty: None, equipment: None },
-    "Toes-to-Bar" => ExerciseInfo { primary: "Abs", secondary: &["Core", "Lats"], kind: ExerciseType::Compound, difficulty: None, equipment: None },
-    "Ab Wheel Rollout" => ExerciseInfo { primary: "Abs", secondary: &["Core", "Lats"], kind: ExerciseType::Isolation, difficulty: None, equipment: None },
-    "Cable Side Bend" => ExerciseInfo { primary: "Obliques", secondary: &["Core"], kind: ExerciseType::Isolation, difficulty: None, equipment: None },
-    "Kneeling Cable Crunch" => ExerciseInfo { primary: "Abs", secondary: &[], kind: ExerciseType::Isolation, difficulty: None, equipment: None },
-    "Bear Crawl" => ExerciseInfo { primary: "Core", secondary: &["Shoulders", "Quads"], kind: ExerciseType::Compound, difficulty: None, equipment: None },
-    "Cable Pallof Press" => ExerciseInfo { primary: "Obliques", secondary: &["Core", "Shoulders"], kind: ExerciseType::Isometric, difficulty: None, equipment: None },
-    "Dead Bug" => ExerciseInfo { primary: "Core", secondary: &[], kind: ExerciseType::Isometric, difficulty: None, equipment: None },
-    "Bird Dog" => ExerciseInfo { primary: "Core", secondary: &["Glutes", "Lower Back"], kind: ExerciseType::Isometric, difficulty: None, equipment: None },
-    "Pallof Press" => ExerciseInfo { primary: "Obliques", secondary: &["Core", "Shoulders"], kind: ExerciseType::Isometric, difficulty: None, equipment: None },
-    "Landmine Rotation" => ExerciseInfo { primary: "Obliques", secondary: &["Core", "Shoulders"], kind: ExerciseType::Compound, difficulty: None, equipment: None },
-    // Misc / full body
-    "Farmer's Carry" => ExerciseInfo { primary: "Traps", secondary: &["Core", "Forearms", "Grip"], kind: ExerciseType::Compound, difficulty: None, equipment: None },
-    "Hip Thrust" => ExerciseInfo { primary: "Glutes", secondary: &["Hamstrings", "Core"], kind: ExerciseType::Compound, difficulty: None, equipment: None },
-    "Glute Bridge" => ExerciseInfo { primary: "Glutes", secondary: &["Hamstrings"], kind: ExerciseType::Compound, difficulty: None, equipment: None },
-    "Glute Kickback (Cable)" => ExerciseInfo { primary: "Glutes", secondary: &["Hamstrings"], kind: ExerciseType::Isolation, difficulty: None, equipment: None },
-    "Cable Abduction" => ExerciseInfo { primary: "Glute Medius", secondary: &[], kind: ExerciseType::Isolation, difficulty: None, equipment: None },
-    "Adductor Machine" => ExerciseInfo { primary: "Adductors", secondary: &[], kind: ExerciseType::Isolation, difficulty: None, equipment: None },
-    "Abductor Machine" => ExerciseInfo { primary: "Glute Medius", secondary: &[], kind: ExerciseType::Isolation, difficulty: None, equipment: None },
-    "Donkey Kick" => ExerciseInfo { primary: "Glutes", secondary: &["Hamstrings"], kind: ExerciseType::Isolation, difficulty: None, equipment: None },
-    "Cable Kickback" => ExerciseInfo { primary: "Glutes", secondary: &["Hamstrings"], kind: ExerciseType::Isolation, difficulty: None, equipment: None },
-    "Machine Glute Kickback" => ExerciseInfo { primary: "Glutes", secondary: &["Hamstrings"], kind: ExerciseType::Isolation, difficulty: None, equipment: None },
-    "Standing Abduction (Band)" => ExerciseInfo { primary: "Glute Medius", secondary: &[], kind: ExerciseType::Isolation, difficulty: None, equipment: None },
-    "Standing Adduction (Cable)" => ExerciseInfo { primary: "Adductors", secondary: &[], kind: ExerciseType::Isolation, difficulty: None, equipment: None },
-    "Single-Leg Glute Bridge" => ExerciseInfo { primary: "Glutes", secondary: &["Hamstrings", "Core"], kind: ExerciseType::Isolation, difficulty: None, equipment: None },
-    "Fire Hydrant (Band or BW)" => ExerciseInfo { primary: "Glute Medius", secondary: &["Core"], kind: ExerciseType::Isolation, difficulty: None, equipment: None },
-    "Sled Drag" => ExerciseInfo { primary: "Full Body", secondary: &["Glutes", "Quads", "Hamstrings"], kind: ExerciseType::Compound, difficulty: None, equipment: None },
-    "Sled Row" => ExerciseInfo { primary: "Back", secondary: &["Biceps", "Core"], kind: ExerciseType::Compound, difficulty: None, equipment: None },
-    "Stepmill" => ExerciseInfo { primary: "Glutes", secondary: &["Quads", "Calves"], kind: ExerciseType::Cardio, difficulty: None, equipment: None },
-    "VersaClimber" => ExerciseInfo { primary: "Full Body", secondary: &["Core", "Shoulders", "Legs"], kind: ExerciseType::Cardio, difficulty: None, equipment: None },
-    "Speed Skater (BW Plyo)" => ExerciseInfo { primary: "Glutes", secondary: &["Quads", "Adductors"], kind: ExerciseType::Plyometric, difficulty: None, equipment: None },
-    "Broad Jump" => ExerciseInfo { primary: "Glutes", secondary: &["Quads", "Calves"], kind: ExerciseType::Plyometric, difficulty: None, equipment: None },
-    "Power Clean" => ExerciseInfo { primary: "Full Body", secondary: &["Traps", "Glutes", "Quads", "Core"], kind: ExerciseType::Compound, difficulty: None, equipment: None },
-    "Clean and Jerk" => ExerciseInfo { primary: "Full Body", secondary: &["Triceps", "Quads", "Glutes"], kind: ExerciseType::Compound, difficulty: None, equipment: None },
-    "Snatch" => ExerciseInfo { primary: "Full Body", secondary: &["Traps", "Glutes", "Core", "Shoulders"], kind: ExerciseType::Compound, difficulty: None, equipment: None },
-    "Assault Bike" => ExerciseInfo { primary: "Quads", secondary: &["Glutes", "Hamstrings"], kind: ExerciseType::Compound, difficulty: None, equipment: None },
-    "Neck Flexion (Harness)" => ExerciseInfo { primary: "Neck", secondary: &[], kind: ExerciseType::Isolation, difficulty: None, equipment: None },
-    "Neck Extension (Harness)" => ExerciseInfo { primary: "Neck", secondary: &[], kind: ExerciseType::Isolation, difficulty: None, equipment: None },
-    "Neck Curl (Weighted)" => ExerciseInfo { primary: "Neck", secondary: &[], kind: ExerciseType::Isolation, difficulty: None, equipment: None },
-    "Neck Extension (Plate)" => ExerciseInfo { primary: "Neck", secondary: &[], kind: ExerciseType::Isolation, difficulty: None, equipment: None },
-    "Band External Rotation" => ExerciseInfo { primary: "Rotator Cuff", secondary: &[], kind: ExerciseType::Isolation, difficulty: None, equipment: None },
-    "Cable L-Fly" => ExerciseInfo { primary: "Rotator Cuff", secondary: &[], kind: ExerciseType::Isolation, difficulty: None, equipment: None },
-    "Cuban Rotation" => ExerciseInfo { primary: "Rotator Cuff", secondary: &["Rear Delts"], kind: ExerciseType::Isolation, difficulty: None, equipment: None },
-    "Cable Internal Rotation" => ExerciseInfo { primary: "Rotator Cuff", secondary: &[], kind: ExerciseType::Isolation, difficulty: None, equipment: None },
-    "Cuban Press" => ExerciseInfo { primary: "Rotator Cuff", secondary: &["Shoulders", "Traps"], kind: ExerciseType::Isolation, difficulty: None, equipment: None },
-    "External Rotation (Cable)" => ExerciseInfo { primary: "Rotator Cuff", secondary: &[], kind: ExerciseType::Isolation, difficulty: None, equipment: None },
-    "Scapular Push-Up" => ExerciseInfo { primary: "Serratus Anterior", secondary: &["Chest", "Shoulders"], kind: ExerciseType::Isolation, difficulty: None, equipment: None },
-    // Legacy synonyms
-    "Bench" => ExerciseInfo { primary: "Chest", secondary: &[], kind: ExerciseType::Compound, difficulty: Some(Difficulty::Intermediate), equipment: Some(Equipment::Barbell) },
-    "Bench Press" => ExerciseInfo { primary: "Chest", secondary: &[], kind: ExerciseType::Compound, difficulty: Some(Difficulty::Intermediate), equipment: Some(Equipment::Barbell) },
-    "Squat" => ExerciseInfo { primary: "Quads", secondary: &[], kind: ExerciseType::Compound, difficulty: None, equipment: None },
-    "Deadlift" => ExerciseInfo { primary: "Back", secondary: &[], kind: ExerciseType::Compound, difficulty: None, equipment: None },
-    "Lying Leg Curl (Machine)" => ExerciseInfo { primary: "Hamstrings", secondary: &["Calves"], kind: ExerciseType::Isolation, difficulty: Some(Difficulty::Beginner), equipment: Some(Equipment::Machine) },
-    "Bicep Curl" => ExerciseInfo { primary: "Biceps", secondary: &["Forearms"], kind: ExerciseType::Isolation, difficulty: None, equipment: None },
+    "Bench" => ExerciseInfo {
+        kind: ExerciseType::Compound,
+        difficulty: Some(Difficulty::Intermediate),
+        equipment: Some(Equipment::Barbell),
+    },
+    "Squat" => ExerciseInfo {
+        kind: ExerciseType::Compound,
+        difficulty: None,
+        equipment: None,
+    },
+    "Deadlift" => ExerciseInfo {
+        kind: ExerciseType::Compound,
+        difficulty: None,
+        equipment: None,
+    },
+    "Push-Up" => ExerciseInfo {
+        kind: ExerciseType::Compound,
+        difficulty: Some(Difficulty::Beginner),
+        equipment: Some(Equipment::Bodyweight),
+    },
+    "Lying Leg Curl (Machine)" => ExerciseInfo {
+        kind: ExerciseType::Isolation,
+        difficulty: Some(Difficulty::Beginner),
+        equipment: Some(Equipment::Machine),
+    },
 };
 
 /// Lookup full information for a given exercise name.
@@ -260,22 +97,21 @@ pub fn info_for(exercise: &str) -> Option<&'static ExerciseInfo> {
     EXERCISES.get(exercise)
 }
 
-/// Convenience wrapper returning only the primary muscle group.
+/// Convenience wrapper returning only the primary muscle group from the
+/// persisted mapping.
 pub fn body_part_for(exercise: &str) -> Option<String> {
-    if let Some(m) = exercise_mapping::get(exercise) {
-        if !m.primary.is_empty() {
-            return Some(m.primary);
+    exercise_mapping::get(exercise).and_then(|m| {
+        if m.primary.is_empty() {
+            None
+        } else {
+            Some(m.primary)
         }
-    }
-    info_for(exercise).map(|i| i.primary.to_string())
+    })
 }
 
 /// Return a sorted list of all unique primary muscle groups.
 pub fn primary_muscle_groups() -> Vec<String> {
     let mut set = BTreeSet::new();
-    for info in EXERCISES.values() {
-        set.insert(info.primary.to_string());
-    }
     for m in exercise_mapping::all().values() {
         if !m.primary.is_empty() {
             set.insert(m.primary.clone());
@@ -289,68 +125,51 @@ pub fn difficulty_for(exercise: &str) -> Option<Difficulty> {
     info_for(exercise).and_then(|i| i.difficulty)
 }
 
-/// Convenience wrapper returning the equipment classification.
+/// Convenience wrapper returning the typical equipment.
 pub fn equipment_for(exercise: &str) -> Option<Equipment> {
     info_for(exercise).and_then(|i| i.equipment)
-}
-
-/// Return the high level category for an exercise from custom mappings.
-pub fn category_for(exercise: &str) -> Option<String> {
-    exercise_mapping::get(exercise).map(|m| m.category)
-}
-
-/// Iterate over the provided workouts and ensure the muscle mapping for each
-/// exercise reflects the latest built-in defaults.
-///
-/// For every unique exercise in `workouts` this will look up the static
-/// [`ExerciseInfo`] and overwrite the primary and secondary muscle groups in the
-/// persistent [`exercise_mapping`] store. The existing category is preserved.
-///
-/// The function returns the number of exercises that were updated. Callers are
-/// responsible for persisting changes via [`exercise_mapping::save`].
-pub fn update_mappings_from_workouts(workouts: &[WorkoutEntry]) -> usize {
-    let mut updated = 0;
-    let mut seen: HashSet<String> = HashSet::new();
-    for w in workouts {
-        if !seen.insert(w.exercise.clone()) {
-            continue;
-        }
-        if let Some(info) = info_for(&w.exercise) {
-            let mut entry = exercise_mapping::get(&w.exercise).unwrap_or_default();
-            let primary = info.primary.to_string();
-            let secondary: Vec<String> = info.secondary.iter().map(|s| s.to_string()).collect();
-            if entry.primary != primary || entry.secondary != secondary {
-                entry.primary = primary;
-                entry.secondary = secondary;
-                exercise_mapping::set(w.exercise.clone(), entry);
-                updated += 1;
-            }
-        }
-    }
-    updated
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::RawWorkoutRow;
 
     #[test]
-    fn updates_mappings() {
-        let workout = WorkoutEntry {
-            date: "2024-01-01".into(),
-            exercise: "Barbell Bench Press".into(),
-            weight: Some(100.0),
-            reps: Some(5),
-            raw: RawWorkoutRow::default(),
-        };
-        // Ensure clean state
-        exercise_mapping::remove(&workout.exercise);
-        let updated = update_mappings_from_workouts(&[workout]);
-        assert_eq!(updated, 1);
-        let mapping = exercise_mapping::get("Barbell Bench Press").unwrap();
-        assert_eq!(mapping.primary, "Chest");
-        assert!(mapping.secondary.contains(&"Triceps".to_string()));
-        exercise_mapping::remove("Barbell Bench Press");
+    fn body_part_for_uses_mapping() {
+        exercise_mapping::set(
+            "Custom".into(),
+            exercise_mapping::MuscleMapping {
+                primary: "Back".into(),
+                secondary: vec![],
+                category: String::new(),
+            },
+        );
+        assert_eq!(body_part_for("Custom"), Some("Back".into()));
+        exercise_mapping::remove("Custom");
+    }
+
+    #[test]
+    fn primary_groups_from_mappings() {
+        exercise_mapping::set(
+            "E1".into(),
+            exercise_mapping::MuscleMapping {
+                primary: "Chest".into(),
+                secondary: vec![],
+                category: String::new(),
+            },
+        );
+        exercise_mapping::set(
+            "E2".into(),
+            exercise_mapping::MuscleMapping {
+                primary: "Legs".into(),
+                secondary: vec![],
+                category: String::new(),
+            },
+        );
+        let groups = primary_muscle_groups();
+        assert!(groups.contains(&"Chest".to_string()));
+        assert!(groups.contains(&"Legs".to_string()));
+        exercise_mapping::remove("E1");
+        exercise_mapping::remove("E2");
     }
 }

--- a/src/exercise_mapping.rs
+++ b/src/exercise_mapping.rs
@@ -8,8 +8,6 @@ use std::time::SystemTime;
 
 use dirs_next as dirs;
 
-use crate::body_parts;
-
 #[derive(Debug, Clone, Serialize, Deserialize, Default)]
 #[serde(default)]
 pub struct MuscleMapping {
@@ -29,6 +27,12 @@ fn path() -> Option<std::path::PathBuf> {
 
 pub fn load() {
     if let Some(p) = path() {
+        if !p.exists() {
+            if let Some(parent) = p.parent() {
+                let _ = std::fs::create_dir_all(parent);
+            }
+            let _ = std::fs::write(&p, include_str!("../data/default_exercise_mapping.json"));
+        }
         if let Ok(data) = std::fs::read_to_string(&p) {
             if let Ok(map) = serde_json::from_str::<HashMap<String, MuscleMapping>>(&data) {
                 *MAPPINGS.lock().unwrap() = map;
@@ -64,20 +68,8 @@ pub fn all() -> HashMap<String, MuscleMapping> {
     MAPPINGS.lock().unwrap().clone()
 }
 
-pub fn all_with_defaults() -> HashMap<String, MuscleMapping> {
-    let guard = MAPPINGS.lock().unwrap();
-    let mut map = HashMap::new();
-    for ex in body_parts::EXERCISES.keys() {
-        map.insert(
-            (*ex).to_string(),
-            guard.get(*ex).cloned().unwrap_or_default(),
-        );
-    }
-    map
-}
-
 pub fn export_all<P: AsRef<Path>>(path: P) -> io::Result<()> {
-    let map = all_with_defaults();
+    let map = all();
     if let Some(parent) = path.as_ref().parent() {
         std::fs::create_dir_all(parent)?;
     }
@@ -88,11 +80,8 @@ pub fn export_all<P: AsRef<Path>>(path: P) -> io::Result<()> {
 
 pub fn import_all<P: AsRef<Path>>(path: P) -> io::Result<()> {
     let data = std::fs::read_to_string(path)?;
-    let mut map: HashMap<String, MuscleMapping> =
+    let map: HashMap<String, MuscleMapping> =
         serde_json::from_str(&data).map_err(|e| io::Error::new(io::ErrorKind::Other, e))?;
-    for ex in body_parts::EXERCISES.keys() {
-        map.entry((*ex).to_string()).or_default();
-    }
     *MAPPINGS.lock().unwrap() = map;
     Ok(())
 }
@@ -118,9 +107,6 @@ pub fn merge_files<P: AsRef<Path>>(paths: &[P]) -> io::Result<()> {
         }
     }
     map = map.into_iter().collect();
-    for ex in body_parts::EXERCISES.keys() {
-        map.entry((*ex).to_string()).or_default();
-    }
     *MAPPINGS.lock().unwrap() = map;
     Ok(())
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -2463,16 +2463,13 @@ impl App for MyApp {
                         self.show_about = true;
                         ui.close_menu();
                     }
-                    if ui.button("Reprocess Workouts").clicked() {
-                        let updated = body_parts::update_mappings_from_workouts(&self.workouts);
-                        if updated > 0 {
-                            exercise_mapping::save();
-                            self.stats = compute_stats(
-                                &self.workouts,
-                                self.settings.start_date,
-                                self.settings.end_date,
-                            );
-                        }
+                    if ui.button("Reload Mappings").clicked() {
+                        exercise_mapping::load();
+                        self.stats = compute_stats(
+                            &self.workouts,
+                            self.settings.start_date,
+                            self.settings.end_date,
+                        );
                         ui.close_menu();
                     }
                     ui.menu_button("Export", |ui| {
@@ -5232,6 +5229,7 @@ fn main() -> eframe::Result<()> {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::exercise_mapping;
     use once_cell::sync::Lazy;
     use std::sync::Mutex;
 
@@ -5534,6 +5532,7 @@ Week 1,\"01 Jan 2024, 10:10\",,desc,Bench Press,,,2,working,135,5,,,\n";
 
     #[test]
     fn exercise_type_filter() {
+        exercise_mapping::load();
         let entries = vec![
             WorkoutEntry {
                 date: "2024-01-01".into(),
@@ -5562,6 +5561,7 @@ Week 1,\"01 Jan 2024, 10:10\",,desc,Bench Press,,,2,working,135,5,,,\n";
 
     #[test]
     fn difficulty_filter() {
+        exercise_mapping::load();
         let entries = vec![
             WorkoutEntry {
                 date: "2024-01-01".into(),
@@ -5590,6 +5590,7 @@ Week 1,\"01 Jan 2024, 10:10\",,desc,Bench Press,,,2,working,135,5,,,\n";
 
     #[test]
     fn equipment_filter() {
+        exercise_mapping::load();
         let entries = vec![
             WorkoutEntry {
                 date: "2024-01-01".into(),

--- a/src/plotting.rs
+++ b/src/plotting.rs
@@ -4,6 +4,7 @@ use egui::{Align2, Color32, FontId, Pos2, Sense, Shape, Stroke, Ui, Vec2};
 use egui_plot::{Bar, BarChart, HLine, Line, PlotPoints, PlotUi, Points, VLine};
 
 use crate::body_parts::body_part_for;
+use crate::exercise_mapping;
 use crate::{
     WeightUnit, WorkoutEntry,
     analysis::{
@@ -1797,6 +1798,7 @@ mod tests {
 
     #[test]
     fn test_body_part_volume_trend() {
+        exercise_mapping::load();
         let lines = body_part_volume_trend(
             &sample_entries(),
             None,
@@ -1895,7 +1897,7 @@ mod tests {
     fn test_body_part_distribution_counts() {
         use crate::analysis::aggregate_sets_by_body_part;
         use std::collections::HashMap;
-
+        exercise_mapping::load();
         let entries = sample_entries();
         let (chart, _) = body_part_distribution(&entries, None, None);
         let bounds = PlotItem::bounds(&chart);
@@ -1909,6 +1911,7 @@ mod tests {
 
     #[test]
     fn test_body_part_pie_counts() {
+        exercise_mapping::load();
         let entries = sample_entries();
         let pie = body_part_pie(&entries, None, None);
         let mut map = std::collections::HashMap::new();


### PR DESCRIPTION
## Summary
- move built-in exercise→muscle mappings to `data/default_exercise_mapping.json`
- load default mappings from JSON and simplify merge/export/import logic
- remove baked-in body part data; rely solely on persisted mappings
- add minimal metadata for filters and reload mappings via menu

## Testing
- `cargo test`
 